### PR TITLE
Config overhaul: connection-spec, NickServ auth/registration, Manual.org

### DIFF
--- a/FIX_CONFIG.org
+++ b/FIX_CONFIG.org
@@ -1,0 +1,388 @@
+#+TITLE: Harlie Configuration System — Analysis and Overhaul Plan
+#+AUTHOR: Brian O'Reilly
+#+DATE: 2026-03-14
+#+OPTIONS: toc:t num:t
+
+* Current State Analysis
+
+** The ~config~ Class (~confobjects.lisp~)
+
+The ~config~ CLOS class has 13 slots. Only 4 are read anywhere in the
+codebase. The remaining 9 are dead code.
+
+*** Slots that are alive
+
+| Slot                   | Used by                                            | Purpose                        |
+|------------------------+----------------------------------------------------+--------------------------------|
+| ~irc-joins~              | ~start-threaded-irc-client-instances~, ~load-contexts~ | IRC server/nick/channel config |
+| ~psql-botdb-credentials~ | 28 call sites across 8 files                       | All database connections       |
+| ~web-server-ports~       | ~start-web-servers~, ~load-contexts~                   | HTTP server port list          |
+| ~web-server-name~        | ~load-contexts~                                      | Hostname for web contexts      |
+
+*** Dead slots
+
+| Slot                     | Reason dead                                              |
+|--------------------------+----------------------------------------------------------|
+| ~irc-server-name~          | Server names live inside ~irc-joins~                       |
+| ~irc-channel-names~        | Channels live inside ~irc-joins~                           |
+| ~irc-nickchannels~         | Populated in every config, read nowhere (see below)      |
+| ~ssl~                      | SSL flag lives inside ~irc-joins~ per server-spec          |
+| ~url-store-type~           | Only one backend exists; flag never consulted            |
+| ~psql-old-credentials~     | Legacy, ~nil~ initform, never touched                      |
+| ~psql-url-new-credentials~ | Never populated, never read                              |
+| ~psql-chain-credentials~   | Never populated; chainer uses ~psql-botdb-credentials~     |
+| ~psql-context-credentials~ | Only a fallback source for ~psql-botdb-credentials~ if nil |
+
+** The ~irc-nickchannels~ Ghost
+
+This is the most operationally dangerous dead slot. It is populated in every
+config variant, documented in the Manual as the way to add channels, and
+yet the IRC client code (~start-threaded-irc-client-instances~) never reads
+it. Only ~irc-joins~ is iterated. An operator editing ~irc-nickchannels~ to
+add or change channels sees no effect and has no obvious indication why.
+
+** The ~irc-joins~ Nested List Structure
+
+~irc-joins~ is the sole source of truth for IRC connections. Its structure
+is deeply nested with implicit positional semantics:
+
+#+begin_src lisp
+:irc-joins '((("irc.libera.chat" :ssl)       ; server-spec tuple
+              (("Jankist" ("#deepsky"))        ; nick-spec: (nick (channels))
+               ("OtherNick" ("#chan" "pass"))  ; nick-spec with channel key
+               ("Third"     ("#foo") "nspass") ; nick-spec with NickServ pw
+               )))
+#+end_src
+
+Hierarchy:
+#+begin_example
+irc-joins
+  └─ server-group: (server-spec nick-specs-list)
+       ├─ server-spec: ("hostname" ssl-keyword)
+       └─ nick-specs-list
+            └─ nick-spec: (nick (channels...) [nickserv-password])
+                 ├─ nick       [string]
+                 ├─ channels   [list] — (first) = channel, (second) = channel key or nil
+                 └─ nickserv-password [optional string]
+#+end_example
+
+The ~channels~ element is a list whose first element is the channel name and
+whose second element, if present, is ambiguously either a channel key
+(password) or a second channel to join. The code always treats it as
+~(channel . key)~, meaning *only one channel is ever joined per nick-spec*,
+and any additional channel names are silently misinterpreted as keys.
+
+** Three Overlapping Channel Representations
+
+The system tracks "what channels the bot is in" in three separate places,
+none of which are kept automatically in sync:
+
+1. *~irc-joins~ in config* (Lisp) — the only one the IRC client uses at runtime
+2. *~contexts~ table* (PostgreSQL) — written once at first-run from ~irc-joins~,
+   never updated again. Config changes are not reflected until manual SQL ~INSERT~.
+3. *~bot-channel~ table* (PostgreSQL) — tracks joined channels for user/ignore
+   persistence; created lazily on join; orthogonal to the contexts table.
+
+The Manual documents that adding a channel requires editing ~config.lisp~ AND
+manually inserting a row into the ~contexts~ table. This is fragile and
+error-prone.
+
+** The Database Context System
+
+*** ~bot-context~ class (~context.lisp~)
+
+Each context represents one bot personality with its associated IRC and web
+configuration:
+- ~bot-nick~ — IRC nickname
+- ~bot-irc-server~ — IRC server hostname
+- ~bot-irc-channel~ — one channel (one per context by schema design)
+- ~bot-web-server~ — web server hostname
+- ~bot-web-port~ — web server port
+- ~bot-uri-prefix~ — base URI path
+
+*** ~contexts~ table schema
+
+#+begin_src sql
+CREATE TABLE contexts (
+    context_id     bigint NOT NULL PRIMARY KEY,
+    context_name   text,     -- IRC nickname
+    irc_server     text,
+    irc_channel    text,     -- ONE channel per row
+    web_server     text,
+    web_port       integer,
+    web_uri_prefix text
+);
+#+end_src
+
+The schema enforces one channel per context, which matches the
+one-connection-per-channel architecture — but the config's ~irc-joins~
+structure allows multiple channels per nick-spec, creating a mismatch.
+
+*** ~load-contexts~ (~init-first-run.lisp~)
+
+Called only on first-run (~initialize-startup-maybe~ traps a ~DATABASE-ERROR~
+to detect an absent database). Subsequently never called again. If the config
+changes, the ~contexts~ table is silently stale.
+
+~load-contexts~ pairs web ports to nick-specs by *popping from a copy of
+~web-server-ports~* in lock-step with the nick-spec iteration. The count and
+order of ~web-server-ports~ entries must exactly match the total number of
+nick-specs across all servers. This is an undocumented invariant with no
+validation.
+
+** Known Bugs in the Current Configuration Code
+
+*** Bug A: ~load-contexts~ passes the server tuple to SQL, not the hostname
+
+#+begin_src lisp
+;; init-first-run.lisp line 29
+(let ((ircserver (car server-spec))   ; BUG: = '("irc.libera.chat" :ssl), not "irc.libera.chat"
+#+end_src
+
+~(car server-spec)~ extracts the whole ~("hostname" :ssl)~ tuple. Contrast
+with ~start-threaded-irc-client-instances~ which correctly uses ~(caar server-spec)~.
+The contexts table therefore stores ~(irc.libera.chat :ssl)~ as the
+~irc_server~ value, not ~"irc.libera.chat"~.
+
+*** Bug B: ~start-web-servers~ only starts one acceptor
+
+#+begin_src lisp
+;; web-server.lisp line 188
+(start (car *acceptors*))   ; only the first, despite creating one per port
+#+end_src
+
+Multiple acceptors are constructed (one per port in ~web-server-ports~) but
+only ~(car *acceptors*)~ is passed to ~start~. All ports beyond the first are
+silently inactive.
+
+*** Bug C: ~url-store.lisp~ captures credentials at class definition time
+
+#+begin_src lisp
+(defclass postmodern-url-store ()
+  ((readwrite-url-db :initform (psql-botdb-credentials *bot-config*) ...)))
+#+end_src
+
+The ~:initform~ expression is evaluated when the class is defined (at load
+time), not when an instance is created. If ~*bot-config*~ is not yet
+configured when this file loads, the URL store receives nil or stale
+credentials.
+
+*** Bug D: ~make-context-entry~ uses raw string interpolation for SQL
+
+#+begin_src lisp
+(query (format nil "INSERT INTO contexts ... VALUES ('~A', '~A', ...)"
+               bot-nick irc-server ...))
+#+end_src
+
+Values are interpolated directly into the SQL string. Any value containing a
+single quote (e.g. a channel name or nick with an apostrophe) will break the
+query. Should use parameterised queries.
+
+** Single Database Credential for Everything
+
+The separate credential slots (~psql-chain-credentials~,
+~psql-url-new-credentials~, etc.) suggest the original intent was to allow
+different PostgreSQL roles for different subsystems. That was never wired up.
+All 28 database call sites use ~psql-botdb-credentials~. The multi-credential
+design is entirely vestigial.
+
+* Proposed Overhaul
+
+** Core Principle
+
+Each IRC connection is a self-contained unit. The config should say exactly
+that: a flat list of connection objects, each carrying everything its
+connection needs, with nothing left to implicit positional coupling between
+separate lists.
+
+** New Data Model
+
+*** New class: ~connection-spec~
+
+#+begin_src lisp
+(defclass connection-spec ()
+  ((server            :initarg :server            :accessor cs-server)
+   (ssl               :initarg :ssl               :accessor cs-ssl
+                      :initform nil)
+   (nick              :initarg :nick              :accessor cs-nick)
+   (channel           :initarg :channel           :accessor cs-channel)
+   (channel-key       :initarg :channel-key       :accessor cs-channel-key
+                      :initform nil)
+   (nickserv-password :initarg :nickserv-password :accessor cs-nickserv-password
+                      :initform nil)
+   (web-port          :initarg :web-port          :accessor cs-web-port)))
+
+(defun make-connection-spec (&rest args)
+  (apply #'make-instance 'connection-spec args))
+#+end_src
+
+*** Simplified ~config~ class — 3 slots
+
+#+begin_src lisp
+(defclass config ()
+  ((db-credentials  :initarg :db-credentials  :accessor db-credentials)
+   (web-server-name :initarg :web-server-name :accessor web-server-name)
+   (connections     :initarg :connections     :accessor connections)))
+
+(defun make-config (&rest args)
+  (apply #'make-instance 'config args))
+#+end_src
+
+All 9 dead slots are removed. ~irc-joins~ and ~web-server-ports~ are replaced
+by ~connections~. All ~psql-*~ slots collapse to ~db-credentials~.
+
+*** New config data format
+
+#+begin_src lisp
+(defparameter *bot-config*
+  (make-config
+   :db-credentials  '("botdb" "fade" nil :unix)
+   :web-server-name "localhost"
+   :connections
+   (list
+    (make-connection-spec
+     :server "irc.libera.chat" :ssl t
+     :nick "Jankist" :channel "#deepsky"
+     :web-port 8888)
+    (make-connection-spec
+     :server "irc.srh.org" :ssl t
+     :nick "chumby" :channel "#trinity" :channel-key "knobjockey"
+     :web-port 5807)
+    (make-connection-spec
+     :server "irc.srh.org" :ssl t
+     :nick "harlie" :channel "#busted"
+     :web-port 5791))))
+#+end_src
+
+Flat, readable, self-documenting. Each connection declares everything it
+needs. No positional coupling. No ambiguous list structure.
+
+** Changes Required, File by File
+
+*** ~confobjects.lisp~
+
+- Replace 13-slot ~config~ class with 3-slot version
+- Add ~connection-spec~ class with ~make-connection-spec~ constructor
+- Remove ~initialize-instance :after~ fallback (no longer needed; ~db-credentials~
+  is always explicit)
+
+*** ~config.lisp~ (and ~config-template.lisp~)
+
+- Rewrite all config variants using ~make-connection-spec~
+- ~irc-nickchannels~ / ~irc-joins~ duplication disappears by construction
+- NickServ passwords, channel keys are now named, not positional
+
+*** ~irc-client.lisp~ — ~start-threaded-irc-client-instances~
+
+Replace the nested ~dolist~ over ~irc-joins~ with a flat iteration:
+
+#+begin_src lisp
+(dolist (cs (connections *bot-config*))
+  (when go?
+    (start-threaded-irc-client-instance
+     (cs-server cs)
+     (if (cs-ssl cs) :ssl :default)
+     (cs-nick cs)
+     (cs-channel cs)
+     (cs-channel-key cs)
+     :nickserv-password (cs-nickserv-password cs))
+    (sleep *inter-connection-delay*)))
+#+end_src
+
+The ~make-irc-client-instance-thunk~ signature also simplifies: ~channel~ and
+~channel-key~ are passed as distinct arguments, removing the ambiguous
+~(first channels)~ / ~(second channels)~ convention.
+
+*** ~init-first-run.lisp~ — ~load-contexts~
+
+- Iterate ~(connections *bot-config*)~ directly; no more nested list navigation
+- Fixes Bug A: ~(cs-server cs)~ is always a plain string
+- Fixes the positional coupling: ~(cs-web-port cs)~ directly, no list popping
+- Use a parameterised upsert: ~INSERT ... ON CONFLICT ... DO UPDATE SET ...~
+  so the function is safe to call on every startup, not only first-run
+- Fixes Bug D: use Postmodern parameterised queries, not ~format~ string interpolation
+
+*** ~init-first-run.lisp~ — ~initialize-startup-maybe~
+
+Call ~load-contexts~ unconditionally (after confirming DB existence), not only
+on the first-run path. The idempotent upsert makes this safe. Config changes
+take effect on next restart without manual SQL.
+
+*** ~web-server.lisp~ — ~start-web-servers~
+
+- Collect ports from ~(mapcar #'cs-web-port (connections *bot-config*))~
+- Fix Bug B: start all acceptors, not just ~(car *acceptors*)~
+  (or make the single-server design explicit and intentional)
+
+*** ~url-store.lisp~
+
+Fix Bug C — defer credential capture to instantiation time:
+
+#+begin_src lisp
+;; Replace the :initform expression with nil and use initialize-instance
+(defclass postmodern-url-store ()
+  ((readwrite-url-db :initform nil :accessor readwrite-url-db)))
+
+(defmethod initialize-instance :after ((store postmodern-url-store) &key)
+  (setf (readwrite-url-db store) (db-credentials *bot-config*)))
+#+end_src
+
+*** Database — ~contexts~ table
+
+Add a unique constraint to support idempotent upserts:
+
+#+begin_src sql
+ALTER TABLE contexts
+  ADD CONSTRAINT contexts_identity_unique
+  UNIQUE (context_name, irc_server, irc_channel);
+#+end_src
+
+** What Does Not Change
+
+- ~bot-irc-connection~ class and all ~connection_pain~ event-driven sequencing
+- All message hooks (privmsg, join, notice, namreply, etc.)
+- ~bot-channel~ table and user/ignore persistence
+- The ~contexts~ table schema (beyond the unique constraint above)
+- Chainer, URL store internals, web routes, plugin dispatch
+
+** Migration Sequence
+
+Each step is independently testable before proceeding to the next.
+
+1. *~confobjects.lisp~* — define ~connection-spec~, simplify ~config~
+2. *~config.lisp~* — rewrite config data using new classes
+3. *~irc-client.lisp~* — simplify ~start-threaded-irc-client-instances~
+   and ~make-irc-client-instance-thunk~ signature
+4. *~init-first-run.lisp~* — idempotent ~load-contexts~, fix Bug A, fix Bug D,
+   move upsert out of first-run-only path
+5. *~url-store.lisp~* — fix Bug C (deferred credential capture)
+6. *~web-server.lisp~* — port list from connections, fix Bug B
+7. *Database* — add unique constraint to ~contexts~ table
+
+* Open Questions
+
+- Should ~web-server-name~ move onto ~connection-spec~ to allow different
+  connections to advertise different hostnames, or is a single hostname
+  per bot image always correct?
+- Should the single-web-server behaviour in ~start-web-servers~ be preserved
+  by design (one acceptor, many virtual hosts) or was multi-acceptor the
+  intent?
+- Is the ~contexts~ table still needed at all once the config is the
+  single source of truth on every startup? Or does it serve a purpose
+  for the URL shortener (~urls.context_id~ foreign key) that justifies
+  keeping it?
+
+* Source Locations
+
+| Symbol                              | File                    | Line |
+|-------------------------------------+-------------------------+------|
+| ~config~ class                        | confobjects.lisp        |   54 |
+| ~make-config~                         | confobjects.lisp        |   69 |
+| ~start-threaded-irc-client-instances~ | irc-client.lisp         |  727 |
+| ~make-irc-client-instance-thunk~      | irc-client.lisp         |  573 |
+| ~load-contexts~                       | init-first-run.lisp     |   21 |
+| ~make-context-entry~                  | init-first-run.lisp     |   73 |
+| ~initialize-startup-maybe~            | init-first-run.lisp     |  103 |
+| ~start-web-servers~                   | web-server.lisp         |  168 |
+| ~postmodern-url-store~ class          | url-store.lisp          |    5 |
+| ~contexts~ table schema               | database/bot-schema.sql |    — |

--- a/HARLIE_ANALYSIS.org
+++ b/HARLIE_ANALYSIS.org
@@ -1,0 +1,511 @@
+#+TITLE: Harlie IRC Bot — Channel Join Failure Analysis
+#+AUTHOR: Brian O'Reilly
+#+DATE: 2026-03-13
+#+OPTIONS: toc:t num:t
+
+* Overview
+
+This document analyses the Harlie IRC bot codebase (~harlie/~) and its primary
+dependency (~cl-irc~) with a focus on the observed failure mode: *the bot does
+not join all configured channels when many channels are present in the
+configuration*.
+
+Three areas are examined:
+1. The Harlie channel-joining code path
+2. The ~cl-irc~ library's protocol handling
+3. The configuration data model
+
+* Project Structure
+
+| File                 | Purpose                                                |
+|----------------------+--------------------------------------------------------|
+| ~harlie.lisp~          | Entry point: ~run-bot~, ~kill-bot~, ~slynky~ REPL            |
+| ~irc-client.lisp~      | All IRC connection and messaging logic (677 lines)     |
+| ~confobjects.lisp~     | ~config~ CLOS class definition                           |
+| ~config.lisp~          | Active site configuration (symlink to config-template) |
+| ~config-template.lisp~ | Example/template configs                               |
+| ~context.lisp~         | Per-server/channel context management                  |
+| ~users.lisp~           | PostgreSQL-backed user, channel, channel-user models   |
+| ~plugins.lisp~         | Plugin dispatch system                                 |
+| ~sleep-timers.lisp~    | Portable timer replacement (was SBCL-specific)         |
+| ~chainer.lisp~         | Markov-chain text generation                           |
+
+Dependencies of note: ~cl-irc~, ~bordeaux-threads~, ~jpl-queues~,
+~postmodern~, ~lparallel~, ~trivial-timeout~, ~hunchentoot~.
+
+* Startup and Channel-Join Code Path
+
+** ~run-bot~ (harlie.lisp)
+
+#+begin_src lisp
+(defun run-bot ()
+  (setf *random-state* (make-random-state t))
+  (start-web-client)
+  (start-web-servers)
+  (initialize-startup-maybe :go? t)
+  (sleep 3)                                  ; wait for web servers
+  (start-threaded-irc-client-instances :go? t)
+  (start-cron)
+  (add-canonical-crons))
+#+end_src
+
+** ~start-threaded-irc-client-instances~ (irc-client.lisp:648)
+
+Iterates the ~irc-joins~ slot of ~*bot-config*~. For each server/port
+specification and each nickname/channel pair within it, spawns a dedicated
+OS thread via ~bordeaux-threads:make-thread~.
+
+#+begin_src lisp
+(dolist (server-spec (irc-joins *bot-config*))
+  (let* ((ircserver     (caar server-spec))
+         (connection-port (or (first (cdar server-spec)) :default)))
+    (dolist (nick-spec (cadr server-spec))
+      (let ((nickname (car nick-spec))
+            (channels (cadr nick-spec)))
+        (when go?
+          (start-threaded-irc-client-instance
+           ircserver connection-port nickname channels))))))
+#+end_src
+
+The ~channels~ value bound here is ~(cadr nick-spec)~ — the second element of
+a nick-spec like ~("Jankist" ("#deepsky"))~.
+
+** ~make-bot-connection~ (irc-client.lisp:604)
+
+Calls ~cl-irc:connect~, which:
+1. Opens a TCP socket (or SSL stream) to the server
+2. Sends ~NICK~ and ~USER~ commands
+3. Adds default hooks
+4. *Returns immediately — without waiting for 001 RPL_WELCOME*
+
+** ~make-irc-client-instance-thunk~ (irc-client.lisp:569)
+
+This is where the actual ~JOIN~ is sent:
+
+#+begin_src lisp
+(if (listp channels)
+    (let ((ch   (first channels))
+          (pass (second channels)))
+      (cl-irc:join connection ch :password pass)
+      (privmsg connection ch "NOTIFY:: Help, I'm a bot!"))
+    (progn
+      (cl-irc:join connection channel)
+      (privmsg connection channel "NOTIFY:: Help, I'm a bot!")))
+
+;; (dolist (channel channels)         ; <-- COMMENTED OUT
+;;   (log:debug ...))
+
+(add-hook connection 'irc::irc-privmsg-message #'threaded-msg-hook)
+;; ... more hooks ...
+(read-message-loop connection)        ; blocks here forever
+#+end_src
+
+* Identified Bugs and Failure Modes
+
+** BUG #1 (Critical): Only One Channel Per Connection Is Ever Joined
+
+This is almost certainly the primary cause of the reported failure.
+
+The ~channels~ value passed to the thunk is, in typical configuration, a list
+of channel names (and optionally a password), e.g.:
+
+#+begin_src lisp
+("#trinity" "#triscuit")   ; intended: join two channels
+("#deepsky")               ; intended: join one channel
+("#trinity" "knobjockey")  ; intended: join #trinity with password
+#+end_src
+
+The code treats this list as a *(channel . maybe-password)* pair, not as a
+list of channels to iterate:
+
+#+begin_src lisp
+(let ((ch   (first channels))   ; → "#trinity"
+      (pass (second channels))) ; → "#triscuit"  (USED AS PASSWORD — WRONG)
+  (cl-irc:join connection ch :password pass))
+#+end_src
+
+*Consequences:*
+- When two channel names appear in a list (intended as two channels to join),
+  only the first is joined.
+- The second name is silently passed as a channel key/password to the JOIN
+  command, causing the server to reject the join with ~ERR_BADCHANNELKEY~
+  (475), which Harlie never observes (no error hook).
+- Any channels beyond the second are completely silently dropped.
+
+*Evidence of the intent to loop:* Lines 587–590 contain a commented-out
+~dolist~ that was presumably the original iteration logic:
+
+#+begin_src lisp
+;; (dolist (channel channels)
+;;   (log:debug "~2&Type of 'channel: ~A~3%" (type-of channel))
+;;   (log:debug "~&~S~3%" channel)
+;;   )
+#+end_src
+
+This was dead-ended, and the replacement code (the current ~if (listp channels)~
+block) handles only a single channel. The loop body was never implemented.
+
+** BUG #2 (Significant): ~irc-nickchannels~ Config Slot Is Never Used
+
+The ~config~ class has an ~irc-nickchannels~ slot (confobjects.lisp:59).
+Example configs populate it:
+
+#+begin_src lisp
+:irc-nickchannels '(("chumby" ("#trinity" "knobjockey"))
+                    ("harlie" ("#busted")))
+#+end_src
+
+However, ~start-threaded-irc-client-instances~ iterates *only* ~irc-joins~.
+The ~irc-nickchannels~ slot is read nowhere in the IRC connection code.
+Any channels listed solely under ~irc-nickchannels~ and not duplicated in
+~irc-joins~ will never be joined.
+
+This creates a maintenance hazard: an operator editing the config may update
+~irc-nickchannels~ while leaving ~irc-joins~ stale, believing both are active.
+
+** BUG #3 (Significant): JOIN Sent Before Registration Confirmed
+
+~cl-irc:connect~ (command.lisp:266) sends ~NICK~ and ~USER~ and returns
+immediately, without waiting for the server's ~001 RPL_WELCOME~. The thunk
+then immediately calls ~cl-irc:join~.
+
+On most modern IRC servers (Inspircd, Charybdis, UnrealIRCd), JOIN commands
+received during registration are queued and replayed after registration
+completes. However:
+- Some network configurations or older servers may reject or silently drop
+  pre-registration JOIN commands.
+- Under load (many simultaneous connections from the same host), server-side
+  processing may be slow enough that a rapid JOIN before 001 is reliably
+  rejected.
+- Services (NickServ, etc.) may also need to identify the nick before certain
+  channels (+r, registered-only) can be joined.
+
+** BUG #4 (Moderate): PRIVMSG Sent to Channel Before JOIN Confirmed
+
+Immediately after sending ~JOIN~, the thunk sends:
+
+#+begin_src lisp
+(privmsg connection ch "NOTIFY:: Help, I'm a bot!")
+#+end_src
+
+This PRIVMSG is sent before the server has acknowledged the JOIN (before any
+hook fires, before ~read-message-loop~ even starts). If the JOIN is rejected or
+slow, this message goes to a channel the bot is not in, generating a silent
+~ERR_NOTONCHANNEL~ (442) from the server, which is never handled.
+
+** BUG #5 (Significant): Undefined Variable ~channel~ in Else Branch
+
+The ~if (listp channels)~ form at line 576 has two branches. The true branch
+correctly binds ~ch~ and ~pass~:
+
+#+begin_src lisp
+(let ((ch   (first channels))
+      (pass (second channels)))
+  (cl-irc:join connection ch :password pass)
+  (privmsg connection ch ...))
+#+end_src
+
+The false branch (line 582), intended for when ~channels~ is a bare string
+atom, references a variable named ~channel~ which is not a parameter and is not
+bound anywhere in the enclosing scope:
+
+#+begin_src lisp
+(progn
+  (cl-irc:join connection channel)     ; 'channel' is UNBOUND
+  (privmsg connection channel ...))
+#+end_src
+
+The function signature is:
+#+begin_src lisp
+(defun make-irc-client-instance-thunk (nickname channels ircserver connection)
+#+end_src
+
+There is no ~channel~ parameter. The name should be ~channels~ or the binding
+~ch~ from the true branch. Because all current configurations pass a list as
+~channels~, the else branch is never reached and this bug is latent — but any
+attempt to pass a bare channel name string would signal an ~unbound-variable~
+error.
+
+** BUG #6 (Moderate): Hooks Registered After JOIN Sent
+
+The ~add-hook~ calls at lines 593–601 occur *after* ~cl-irc:join~ is called
+at line 580. In theory, the ~irc-join-message~ hook at line 598 could miss the
+bot's own JOIN acknowledgment if the server is fast enough to respond before
+~read-message-loop~ is entered.
+
+In practice, because the socket is buffered and ~read-message-loop~ is started
+in the same thread, this is unlikely to lose messages — the socket buffer will
+hold them. However, there is no guarantee, particularly under high load or
+with short server-side processing times.
+
+** BUG #7 (Minor): No Error Recovery for Failed JOINs
+
+~cl-irc~ has no default hooks for these IRC error codes:
+- ~403 ERR_NOSUCHCHANNEL~
+- ~405 ERR_TOOMANYCHANNELS~
+- ~442 ERR_NOTONCHANNEL~
+- ~471 ERR_CHANNELISFULL~
+- ~473 ERR_INVITEONLYCHAN~
+- ~474 ERR_BANNEDFROMCHAN~
+- ~475 ERR_BADCHANNELKEY~
+
+Harlie also adds no custom hooks for these. A failed JOIN is silently ignored
+with no retry, no log entry, and no operator alert.
+
+* cl-irc Library Issues
+
+** No Rate Limiting in ~multi-join~
+
+~cl-irc~ provides a ~multi-join~ method (command.lisp:175):
+
+#+begin_src lisp
+(defmethod multi-join ((connection connection) (channels list))
+  (dolist (channel channels)
+    (join connection channel)))
+#+end_src
+
+There is no delay between ~JOIN~ commands. IRC servers implement flood
+protection; sending many JOINs in rapid succession can trigger rate limiting,
+throttling, or even a temporary ban (~KILL~ or ~Z-LINE~). Harlie does not use
+~multi-join~ (it uses ~cl-irc:join~ directly), but the same problem applies:
+if many connections each send a JOIN at startup simultaneously, the server may
+interpret the traffic as flooding.
+
+** ~connect~ Does Not Wait for 001
+
+As noted above, ~cl-irc:connect~ returns immediately after sending ~NICK~ and
+~USER~. There is no call to ~read-message-loop~ or any synchronous read of the
+welcome message. The caller must not send JOIN until it has received ~001~, but
+nothing in the library enforces or facilitates this.
+
+** 1024-Byte Read Buffer
+
+~read-protocol-line~ (utility.lisp) uses a hard-coded 1024-byte buffer:
+
+#+begin_src lisp
+(read-sequence-until (network-stream connection)
+                     (make-array 1024 :element-type '(unsigned-byte 8)
+                                      :fill-pointer t)
+                     '(10))
+#+end_src
+
+The IRC protocol caps messages at 512 bytes (including CRLF), so this buffer
+is sufficient for all well-formed IRC protocol messages. However, if a server
+sends a malformed or extended message (some IRCv3 servers with tags can exceed
+512 bytes), truncation occurs, causing the next read to start mid-message and
+desynchronise the parser. This is a latent risk rather than the primary cause
+of the reported failure.
+
+** No Hook for ~no-such-reply~
+
+When ~read-irc-message~ encounters a message type with no registered handler,
+~no-such-reply~ is signalled. Unless ~*unknown-reply-hook*~ is set (it is not
+by Harlie), the message is silently dropped. Any server-specific numerics, or
+future IRC extension responses, are lost.
+
+* Configuration Model Analysis
+
+** Active Config (~*sr-4-config*~, current config.lisp)
+
+#+begin_src lisp
+(defparameter *sr-4-config*
+  (make-config
+   :irc-server-name "irc.srh.org"
+   :irc-nickchannels '(("chumby" ("#trinity" "knobjockey"))
+                       ("harlie" ("#busted")))     ; <-- NEVER USED
+   :ssl :ssl
+   :irc-joins '((("irc.libera.chat" :ssl)
+                 (("Jankist" ("#deepsky")))))       ; <-- ONLY THIS IS USED
+   ...))
+#+end_src
+
+In the current active config, only one channel (~#deepsky~) on one server
+(libera.chat) is configured via ~irc-joins~. The ~irc-nickchannels~ entries
+for ~chumby~ and ~harlie~ on ~irc.srh.org~ are present but completely inert.
+
+** ~*harlot-config*~ Template Example (Demonstrates the Multi-Channel Bug)
+
+#+begin_src lisp
+:irc-joins '((("irc.srh.org" :none)
+              (("Harlot" ("#trinity" "#triscuit")))))
+#+end_src
+
+With this config, ~channels = ("#trinity" "#triscuit")~. The thunk will join
+~#trinity~ with the password ~"#triscuit"~. The channel ~#triscuit~ will never
+be joined.
+
+** Structural Ambiguity in the ~channels~ Value
+
+The list ~("#chan" "password")~ is structurally identical to ~("#chan1" "#chan2")~.
+The code always interprets it as /(channel . password)/, never as a list of
+channels to join. There is no sentinel or type tag to distinguish the two
+intended meanings. This is a latent design ambiguity that makes it easy to
+write a configuration that appears correct but silently misbehaves.
+
+* Hypotheses (Ranked by Likelihood)
+
+** Hypothesis 1 (Most Likely): Multi-Channel Config Interpreted as Channel+Password
+
+If the operator's production ~config.lisp~ lists multiple channels per nick
+entry, e.g.:
+
+#+begin_src lisp
+(("botNick" ("#chan1" "#chan2" "#chan3")))
+#+end_src
+
+then ~(first channels) = "#chan1"~ and ~(second channels) = "#chan2"~ is
+passed as a (wrong) password. Only ~#chan1~ is joined. ~#chan2~ and ~#chan3~
+are silently dropped.
+
+*This is consistent with "fails to join some channels when there are many."*
+
+** Hypothesis 2 (Likely): ~irc-nickchannels~ Populated Instead of ~irc-joins~
+
+If the operator maintains channels under ~irc-nickchannels~ (which looks like
+the "obvious" place based on its name), and does not also duplicate them under
+~irc-joins~, those channels will never be joined. There is no warning.
+
+*This is consistent with channels appearing in configuration but never joined.*
+
+** Hypothesis 3 (Plausible): Server-Side Flood / Connection-Rate Limiting
+
+If many nick+channel entries are configured (one connection per entry, per
+current architecture), a burst of simultaneous TCP connections from the same
+IP address can trigger server-side flood protection. The server may silently
+close some connections, require CAPTCHA/SASL authentication, or impose a
+connection delay that causes the join handshake to time out.
+
+On Libera.chat and similar networks, unregistered nicks or nicks without SASL
+authentication face tighter limits.
+
+** Hypothesis 4 (Plausible): JOIN Sent Before 001 — Server Rejects During Registration
+
+Because ~cl-irc:connect~ returns without waiting for ~001~, the JOIN is sent
+before registration is complete. While most servers queue this, some may not,
+particularly if NickServ identification is required before joining certain
+channels.
+
+** Hypothesis 5 (Less Likely): Timing Race — Hooks Not Set Before JOIN Response
+
+The hooks are added after the JOIN command is sent. On a very fast local
+network connection, it is theoretically possible that the server's JOIN
+acknowledgment arrives and is lost because ~read-message-loop~ has not started.
+In practice the socket buffer makes this unlikely.
+
+** Hypothesis 6 (Background): Network / Server Tightening
+
+A git commit (~aa2e917~) is titled "libera.chat is tightening its connection
+criteria", indicating the operator has observed that Libera.chat is imposing
+stricter rules on connections. Stricter SASL/nick-registration requirements,
+per-IP connection limits, or mandatory handshake pacing could cause any or all
+simultaneous connections to be refused. This is an external factor that
+amplifies the other bugs.
+
+* Additional Architectural Concerns
+
+** No Reconnection Logic
+
+The ~TODO.org~ file explicitly lists this as unimplemented:
+
+#+begin_example
+- [ ] Smart rejoin.  Detect disconnects from server.
+#+end_example
+
+When ~read-message-loop~ exits (network drop, server kick, timeout), the
+thread terminates with no restart or rejoin. Every lost connection requires a
+manual bot restart.
+
+** Thread-Per-Message Model
+
+~threaded-msg-hook~ spawns a new ~bordeaux-threads~ thread for every incoming
+~PRIVMSG~:
+
+#+begin_src lisp
+(defun threaded-msg-hook (message)
+  (make-thread #'(lambda () (msg-hook message nil))))
+#+end_src
+
+There is no thread pool, no limit on concurrent threads, and no back-pressure.
+Under heavy traffic (e.g., a busy channel after joining), this could exhaust
+OS thread resources or cause excessive context switching. The same pattern
+applies to ~threaded-action-hook~.
+
+** Database / Config Schema Mismatch
+
+The ~contexts~ PostgreSQL table (from ~schema.sql~) stores one channel per
+context row:
+
+#+begin_example
+context_name | irc_server | irc_channel | web_server | web_port
+#+end_example
+
+The Lisp config model supports multiple channels per nick. There is no
+migration path between a multi-channel config and the database schema. If the
+database is used to enumerate active channels (e.g., by ~initialize-startup-maybe~),
+it may disagree with the Lisp config, causing channels present in one but not
+the other to be silently omitted.
+
+* Recommendations
+
+*** Short Term
+
+1. *Fix ~make-irc-client-instance-thunk~ to iterate all channels.* The ~channels~
+   value should be a list of channel-specs; the current "first = channel,
+   second = password" convention should be preserved for single-channel entries
+   but a proper loop is needed for multiple channels. Consider a per-channel
+   plist or two-element list convention, e.g. ~(("#chan" . "pass") "#chan2")~,
+   and document it.
+
+2. *Audit ~irc-joins~ vs ~irc-nickchannels~.* Either remove ~irc-nickchannels~
+   (it is unused) or add code to merge it into the join process. Having a
+   dead config slot is a maintenance hazard.
+
+3. *Add error hooks for JOIN failures.* At minimum, log 403, 405, 442, 471,
+   473, 474, 475 so that failed joins are observable.
+
+*** Medium Term
+
+4. *Wait for 001 before sending JOIN.* Either poll ~read-message~ until
+   ~irc-rpl_welcome-message~ fires, or restructure the startup hook to send
+   JOIN from within the ~irc-rpl_welcome-message~ handler.
+
+5. *Rate-limit JOIN commands.* Add an inter-join delay (100–500 ms) when joining
+   multiple channels, to avoid triggering server flood protection.
+
+6. *Send PRIVMSG after JOIN is confirmed.* Move the identification PRIVMSG into
+   the ~irc-join-message~ hook, not immediately after the raw JOIN send.
+
+*** Long Term
+
+7. *Consider a single connection with ~multi-join~.* Rather than one TCP
+   connection per channel/nick, a single authenticated connection joining many
+   channels is more typical, more efficient, and avoids per-IP connection limits.
+   This requires refactoring the config model.
+
+8. *Set ~*unknown-reply-hook*~* to log unrecognised server numerics, making
+   server-side errors visible during debugging.
+
+9. *Implement reconnection.* The ~read-message-loop~ exit should trigger an
+   exponential-backoff reconnect and channel rejoin sequence.
+
+10. *Cap per-message threads or use a thread pool.* The current one-thread-per-PRIVMSG
+    model is unbounded. A lparallel work queue (already a dependency) would be
+    more robust.
+
+* Appendix: Key Source Locations
+
+| Symbol                              | File             | Line |
+|-------------------------------------+------------------+------|
+| ~run-bot~                             | harlie.lisp      | ~17~   |
+| ~start-threaded-irc-client-instances~ | irc-client.lisp  | ~648~  |
+| ~start-threaded-irc-client-instance~  | irc-client.lisp  | ~631~  |
+| ~make-bot-connection~                 | irc-client.lisp  | ~604~  |
+| ~make-irc-client-instance-thunk~      | irc-client.lisp  | ~569~  |
+| ~cl-irc:join~                         | command.lisp     | ~167~  |
+| ~cl-irc:connect~                      | command.lisp     | ~266~  |
+| ~cl-irc:multi-join~                   | command.lisp     | ~175~  |
+| ~read-protocol-line~                  | utility.lisp     | ~132~  |
+| ~read-message-loop~                   | protocol.lisp    | ~342~  |
+| ~config~ class                        | confobjects.lisp | ~54~   |
+| ~*sr-4-config*~                       | config.lisp      | ~58~   |
+| Commented-out channel dolist        | irc-client.lisp  | ~587~  |

--- a/Manual.org
+++ b/Manual.org
@@ -1,0 +1,213 @@
+#+TITLE: Harlie Operator's Manual
+#+AUTHOR: Brian O'Reilly
+#+OPTIONS: toc:t num:t
+
+* Acceptance Testing
+
+When you've just upgraded to a newer version of the Lisp toolchain and
+you want to validate the bot's behaviour, you can run this acceptance
+test procedure.  It should only take a minute or two, and it puts the
+bot through its paces, validating that each significant subsystem is
+working to at least some minimal degree.
+
+It's certainly possible for some plugins to be broken or for some subtle
+bug to have crept into some part of the bot, and for the acceptance test
+procedure to pass anyway.  This is just intended as a quick once-over to
+check that the bot is fit for service after bumping the toolchain or
+otherwise restarting.
+
+- In channel, use the command ~!help~.
+  This demonstrates that the bot is capable of receiving and sending
+  messages through the IRC client library, and that it can work out a
+  web port to display, which shows that its context subsystem is
+  working.
+
+- In a web browser, pull up the help URL the bot has given you.
+  This shows that the web server subsystem is working, and further
+  verifies that the context subsystem is sane.
+
+- Edit the URL in your web browser to change ~/help~ to ~/source~.
+  Further exercises the web server subsystem.
+
+- In the web browser, click on one of the source files.
+  More web server validation.  Also shows whether the Lisp prettyprint
+  library is working.
+
+- In your web browser, delete the portion of the URL after the port number.
+  This will bring up the list of shortened URLs in the current context.
+  The database client library must be used to pull these up; if it
+  works, the database is readable.
+
+- Click on one of the titles and verify that it pulls up the original target.
+  Exercises a different code path through the web server; also further
+  verifies that the database read code for the URL shortener is working.
+
+- In IRC, use the ~!metar~ command.
+  The web client code is exercised by this command.  Sometimes a
+  particular airport's weather data has not been updated, so spurious
+  errors can be seen here.
+
+- In IRC, issue the ~!status full~ command.
+  This reads the database for the Markov chainer, again exercising the
+  context code.
+
+- In IRC, issue the ~!babble~ and/or ~!haiku~ commands.
+  Demonstrates that the chainer can read from its database and perform
+  its most complex function, chaining an output together.
+
+- In IRC, type something for the bot to see.  Then issue either ~!status~
+  or ~!status full~ again.  Verify that the "I know n phrases" response
+  has been bumped up.
+  This shows that the chainer database can be written as well as read.
+
+* Initializing the Database
+
+You'll need to install PostgreSQL and create a database instance for the bot.
+
+#+begin_src sh
+createdb botdb
+#+end_src
+
+The file ~database/bot-schema.sql.template~ contains the database schema.
+Before applying it, substitute the PostgreSQL username that will own the
+bot's tables:
+
+#+begin_src sh
+sed 's/<bot_runner_uid>/BOT-OWNER/g' \
+    database/bot-schema.sql.template > database/bot-schema.sql
+psql botdb -f database/bot-schema.sql
+#+end_src
+
+where ~BOT-OWNER~ is the name of the PostgreSQL user who owns the bot
+database (usually also the Linux username that starts the bot processes).
+
+* Adding a New Channel
+
+Edit ~config.lisp~.  The ~*bot-config*~ defparameter holds a ~make-config~
+form with a ~:connections~ list.  Add one ~make-connection-spec~ form to
+that list for the new nick:
+
+#+begin_src lisp
+(make-connection-spec
+ :server   "irc.libera.chat" :ssl t
+ :nick     "NewNick"
+ :channel  "#newchannel"
+ :web-port 9000)            ; pick an unused port
+#+end_src
+
+Optional fields — omit if not needed:
+
+#+begin_src lisp
+ :channel-key       "channelpassword"
+ :nickserv-password (uiop:getenv "HARLIE_NICKSERV_PASSWORD")
+ :nickserv-email    (uiop:getenv "HARLIE_NICKSERV_EMAIL")
+#+end_src
+
+Passwords should never be written as literals in ~config.lisp~.  Use
+~uiop:getenv~ to read them from the environment at startup, and export
+the variables from the shell session that starts the bot:
+
+#+begin_src sh
+export HARLIE_NICKSERV_PASSWORD="your-nickserv-password"
+export HARLIE_NICKSERV_EMAIL="your@email.com"
+#+end_src
+
+Add these exports to the shell profile (~/.bash_profile~, ~/.zprofile~,
+or equivalent) that owns the bot process so they survive reboots.  If
+the bot runs under a dedicated system account, put them in that
+account's profile or in a sourced credentials file that is not
+world-readable (~chmod 600~).
+
+** NickServ authentication and registration
+
+When ~:nickserv-password~ is set, the bot authenticates with NickServ
+before joining the channel.  The connection passes through these states:
+
+#+begin_example
+:connecting → :registered → :identifying → :joining → :joined
+                                  ↓
+                            :registering ──────────────↑
+#+end_example
+
+1. After ~RPL_WELCOME~ (numeric 001), the bot sends ~IDENTIFY~ to NickServ.
+
+2. If NickServ confirms identification ("You are now identified" or
+   "You are now logged in"), the bot joins the channel.
+
+3. If NickServ replies that the nick is not registered, the behaviour
+   depends on whether ~:nickserv-email~ is also set:
+
+   - *With* ~:nickserv-email~: the bot sends ~REGISTER~ to NickServ,
+     enters state ~:registering~, and proceeds to join once NickServ
+     acknowledges.  The nick will be unverified until you click the
+     activation link in the email; on the next restart ~IDENTIFY~ will
+     succeed normally.
+
+   - *Without* ~:nickserv-email~: the bot logs a warning and joins
+     without identification.
+
+Restart the bot.  On startup, ~load-contexts~ reads ~*bot-config*~ and
+upserts one row into the ~contexts~ table for each ~connection-spec~.
+No manual SQL is required.
+
+The contexts table will look like this after restart:
+
+#+begin_example
+botdb=# SELECT context_id, context_name, irc_server, irc_channel, web_port
+        FROM contexts;
+ context_id | context_name |    irc_server    | irc_channel | web_port
+------------+--------------+------------------+-------------+----------
+          1 | Jankist      | irc.libera.chat  | #deepsky    |     8888
+          2 | NewNick      | irc.libera.chat  | #newchannel |     9000
+#+end_example
+
+* Migrating a Legacy Installation
+
+Legacy Harlie instances used the old 13-slot ~config~ class with
+~irc-joins~, ~web-server-ports~, and ~psql-botdb-credentials~.  Two
+tools handle the upgrade.
+
+** Step 1 — Translate the config (while the bot is still running)
+
+Connect to the running legacy bot via Slynk and evaluate:
+
+#+begin_src lisp
+(load "/path/to/migrate-from-legacy.lisp")
+(harlie::run-lisp-migration)
+#+end_src
+
+This reads the live ~*bot-config*~, converts it to the new
+~connection-spec~ format, writes the result to ~new-config.lisp~
+alongside the Harlie source tree (~*syspath*~), and prints a checklist.
+Review ~new-config.lisp~, then stop the bot and copy it into place as
+~config.lisp~.
+
+** Step 2 — Migrate the database
+
+#+begin_src sh
+bash migrate.sh
+#+end_src
+
+This backs up the database, repairs any corrupted ~irc_server~ values (a
+bug in the old ~load-contexts~ that stored tuple strings instead of
+hostnames), collapses any duplicate ~contexts~ rows, and adds the unique
+constraint required by the new idempotent upsert.
+
+Options:
+
+| Flag        | Default      | Purpose                              |
+|-------------+--------------+--------------------------------------|
+| ~--db~      | ~botdb~      | PostgreSQL database name             |
+| ~--user~    | current user | PostgreSQL username                  |
+| ~--dry-run~ | off          | Report what would be done; no writes |
+
+** Step 3 — Update the code and restart
+
+#+begin_src sh
+git checkout unfuck_configuration_and_state
+# start the bot normally
+#+end_src
+
+~load-contexts~ will sync the ~contexts~ table from the config on every
+subsequent startup — no further manual SQL is ever needed to add or
+change channels.

--- a/chainer.lisp
+++ b/chainer.lisp
@@ -16,7 +16,7 @@
 
 (defun chain-in (context toklist)
   (unless (< (length toklist) 3)
-    (with-connection (psql-botdb-credentials *bot-config*)
+    (with-connection (db-credentials *bot-config*)
       (do* ((word1 *sentinel* word2)
 	    (word2 *sentinel* word3)
 	    (word3 (pop toklist) (pop toklist))
@@ -29,7 +29,7 @@
 
 (defun count-phrases (context)
   "Return the number of entries in the words table."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (:select
 	    (:raw "count(*)")
 	    :from 'words
@@ -66,7 +66,7 @@
 the chain, and also the number of trials before finding it."
   (handler-case
       (trivial-timeout:with-timeout (3)
-	(with-connection (psql-botdb-credentials *bot-config*)
+	(with-connection (db-credentials *bot-config*)
 	  (let ((numrows (query (:select (:raw "max(row_num)") :from 'words) :single)))
 	    (do* ((rownum (random (1+ numrows)) (random (1+ numrows)))
 		  (r (fetch-start context rownum) (fetch-start context rownum))
@@ -109,7 +109,7 @@ the chain, and also the number of trials before finding it."
 
 (defun random-words (context n &optional (wordp #'identity))
   "Return n random words from the chaining db, filtering with predicate wordp."
-  (let ((readcreds (psql-botdb-credentials *bot-config*))
+  (let ((readcreds (db-credentials *bot-config*))
         (readconid (chain-read-context-id context))
         (default-trigger (random-canned-words n)))
     (handler-case
@@ -160,7 +160,7 @@ the chain, and also the number of trials before finding it."
 (defun chain (context &optional w1 w2)
   "Generate a full random chain.  If desired, you can specify the first
 word or two of the chain.  Returns a list of strings."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     ;; If w1 and/or w2 are provided, use them.  Otherwise use sentinel values.
     (destructuring-bind (a b) (argshift *sentinel* w1 w2)
       (do* ((word1 a word2)

--- a/config-template.lisp
+++ b/config-template.lisp
@@ -38,41 +38,51 @@ has a chaining database. shuffled for freshness.")
                               "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36"
                               "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1"))
 
-;; these are exmaples.
+;; these are examples.
 (defparameter *harlot-config*
-  (make-config :irc-server-name "irc.srh.org"
-	       :irc-nickchannels '(("Harlot" ("#trinity")))
-	       :irc-joins '((("irc.srh.org" :none) (("Harlot" ("#trinity" "#triscuit")))))
-	       :web-server-name "127.0.0.1"
-	       :web-server-ports '(5791)
-	       :url-store-type :psql
-	       :psql-botdb-credentials '("botdb" "tuxedo" nil :unix)))
+  (make-config
+   :db-credentials  '("botdb" "tuxedo" nil :unix)
+   :web-server-name "127.0.0.1"
+   :connections
+   (list
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "Harlot" :channel "#trinity"
+     :web-port 5791))))
 
 (defparameter *sr-4-config*
-  (make-config :irc-server-name "irc.srh.org"
-	       :irc-nickchannels '(("SR-4" ("#trinity")))
-	       :irc-joins '((("irc.srh.org" :none) (("SR-4" ("#trinity")))))
-	       :web-server-name "localhost"
-	       :web-server-ports '(5791)
-	       :url-store-type :psql
-	       :psql-botdb-credentials '("botdb" "fade" nil :unix)))
+  (make-config
+   :db-credentials  '("botdb" "fade" nil :unix)
+   :web-server-name "localhost"
+   :connections
+   (list
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "SR-4" :channel "#trinity"
+     :web-port 5791))))
 
 (defparameter *combined-config*
-  (make-config :irc-server-name "irc.srh.org"
-               :irc-nickchannels '(("semaphor" ("#deepsky"))
-                                   ("Bootsy" ("#funkrehab"))
-                                   ("shogun" ("#walled"))
-                                   ("thugster" ("#wallednoc")))
-	       :irc-joins '((("irc.srh.org" :none)
-			     (("semaphor" ("#deepsky"))
-			      ("Bootsy" ("#funkrehab"))
-			      ("shogun" ("#walled"))
-			      ("thugster" ("#wallednoc")))))
-               :web-server-name "deepsky.com"
-               :web-server-ports '(7080 8080 8090 9099)
-               :url-store-type :psql
-               ;; :psql-botdb-credentials '("botdb" "semaphor" nil :unix)
-               :psql-botdb-credentials *bot-database-credentials*))
+  (make-config
+   :db-credentials  *bot-database-credentials*
+   :web-server-name "deepsky.com"
+   :connections
+   (list
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "semaphor" :channel "#deepsky"
+     :web-port 7080)
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "Bootsy" :channel "#funkrehab"
+     :web-port 8080)
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "shogun" :channel "#walled"
+     :web-port 8090)
+    (make-connection-spec
+     :server "irc.srh.org" :ssl nil
+     :nick "thugster" :channel "#wallednoc"
+     :web-port 9099))))
 
 (defparameter *bot-config* *combined-config*)
 

--- a/confobjects.lisp
+++ b/confobjects.lisp
@@ -61,6 +61,8 @@
                       :initform nil)
    (nickserv-password :initarg :nickserv-password :accessor cs-nickserv-password
                       :initform nil)
+   (nickserv-email    :initarg :nickserv-email    :accessor cs-nickserv-email
+                      :initform nil)
    (web-port          :initarg :web-port          :accessor cs-web-port)))
 
 (defun make-connection-spec (&rest args)

--- a/confobjects.lisp
+++ b/confobjects.lisp
@@ -47,33 +47,35 @@
 
 (in-package :harlie)
 
-;;; a transliteration to a CLOS class of the struct that formerly
-;;; contained the configuration information for the various channel
-;;; personalities of a given image containing a harlie instance.
+;;; Each IRC connection is a self-contained unit.  connection-spec carries
+;;; everything one bot personality needs: server, nick, channel, and the
+;;; web port that serves its URL-shortener context.
+
+(defclass connection-spec ()
+  ((server            :initarg :server            :accessor cs-server)
+   (ssl               :initarg :ssl               :accessor cs-ssl
+                      :initform nil)
+   (nick              :initarg :nick              :accessor cs-nick)
+   (channel           :initarg :channel           :accessor cs-channel)
+   (channel-key       :initarg :channel-key       :accessor cs-channel-key
+                      :initform nil)
+   (nickserv-password :initarg :nickserv-password :accessor cs-nickserv-password
+                      :initform nil)
+   (web-port          :initarg :web-port          :accessor cs-web-port)))
+
+(defun make-connection-spec (&rest args)
+  (apply #'make-instance 'connection-spec args))
+
+;;; Top-level bot configuration: one database credential set, the web
+;;; hostname, and a flat list of connection-spec objects.
 
 (defclass config ()
-  ((irc-server-name :initarg :irc-server-name :accessor irc-server-name)
-   (irc-channel-names :initarg :irc-channel-names :accessor irc-channel-names)
-   (irc-joins :initarg :irc-joins :accessor irc-joins)
-   (ssl :initarg :ssl :initform :none :accessor ssl)
-   (irc-nickchannels :initarg :irc-nickchannels :accessor irc-nickchannels)
+  ((db-credentials  :initarg :db-credentials  :accessor db-credentials)
    (web-server-name :initarg :web-server-name :accessor web-server-name)
-   (web-server-ports :initarg :web-server-ports :accessor web-server-ports)
-   (url-store-type :initarg :url-store-type :accessor url-store-type)
-   (psql-old-credentials :initarg :psql-old-credentials :initform nil :accessor psql-old-credentials)
-   (psql-url-new-credentials :initarg :psql-url-new-credentials :accessor psql-url-new-credentials)
-   (psql-chain-credentials :initarg :psql-chain-credentials :accessor psql-chain-credentials)
-   (psql-context-credentials :initarg :psql-context-credentials :accessor psql-context-credentials)
-   (psql-botdb-credentials :initarg :psql-botdb-credentials :initform nil :accessor psql-botdb-credentials)))
+   (connections     :initarg :connections     :accessor connections)))
 
 (defun make-config (&rest args)
   (apply #'make-instance 'config args))
-
-(defmethod initialize-instance :after ((conf config) &key)
-  (with-accessors ((botdb psql-botdb-credentials) (ctxt psql-context-credentials))
-      conf
-    (when (not botdb)
-      (setf botdb ctxt))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; confobjects.lisp ends here

--- a/context.lisp
+++ b/context.lisp
@@ -11,7 +11,7 @@
    (bot-uri-prefix :initarg :bot-uri-prefix :initform nil :accessor bot-uri-prefix)))
 
 (defmethod initialize-instance :after ((context bot-context) &key)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let* ((context-query-head '(:select 'context-name 'irc-server 'irc-channel
                                  'web-server 'web-port 'web-uri-prefix
 				 :from 'contexts))
@@ -32,7 +32,7 @@
 	(setf (bot-uri-prefix context) (sixth conlist))))))
 
 (defun chain-context (nick)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (:select 'context-id
 	    :from 'contexts
 	    :where (:= (:raw "lower(context_name)")
@@ -55,7 +55,7 @@
   (:documentation "Returns the context ID for reading the URL DB in a given context."))
 
 (defun url-context (port)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (:select 'context-id
 	    :from 'contexts
 	    :where (:= 'web-port port))

--- a/database/bot-schema.sql.template
+++ b/database/bot-schema.sql.template
@@ -366,6 +366,14 @@ ALTER TABLE ONLY public.contexts
 
 
 --
+-- Name: contexts contexts_identity_unique; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.contexts
+    ADD CONSTRAINT contexts_identity_unique UNIQUE (context_name, irc_server, irc_channel);
+
+
+--
 -- Name: harlie_user harlie_user_current_handle_key; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
 --
 

--- a/init-first-run.lisp
+++ b/init-first-run.lisp
@@ -12,110 +12,59 @@ the appropriate context."
           do (do-chain-aux ctx l))))
 
 (defun fix-bot-herder (sqlfile)
-  (let* ((bot-herder (second (psql-botdb-credentials *bot-config*)))
+  (let* ((bot-herder (second (db-credentials *bot-config*)))
          (file-contents (rutils:slurp sqlfile))
          (updated-contents (cl-ppcre:regex-replace-all "\<bot_runner_uid\>" file-contents bot-herder)))
     (with-open-file (s sqlfile :direction :output :if-exists :supersede)
       (write-sequence updated-contents s))))
 
-(defun load-contexts (&key (bstate *bot-config*) (go? nil))
-  "
-   context_id | context_name | irc_server  | irc_channel | web_server | web_port | web_uri_prefix 
-  ------------+--------------+-------------+-------------+------------+----------+----------------
-            1 | chumby       | irc.srh.org | #trinity    | localhost  |     5749 | /
-  "  
+(defun make-context-entry (bot-nick irc-server irc-channel web-server web-port uri-prefix)
+  "Upsert one row into the contexts table using parameterised queries.
+Safe to call on every startup; the ON CONFLICT clause makes it idempotent."
+  (execute
+   "INSERT INTO contexts (context_name, irc_server, irc_channel,
+                          web_server, web_port, web_uri_prefix)
+    VALUES ($1, $2, $3, $4, $5, $6)
+    ON CONFLICT (context_name, irc_server, irc_channel)
+    DO UPDATE SET web_server     = EXCLUDED.web_server,
+                  web_port       = EXCLUDED.web_port,
+                  web_uri_prefix = EXCLUDED.web_uri_prefix"
+   bot-nick irc-server irc-channel web-server web-port uri-prefix))
 
-  (dolist (server-spec (irc-joins bstate))
-    (let ((ircserver (car server-spec))
-          (web-ports (copy-seq (web-server-ports *bot-config*))))
-      (log:debug "~&IRC Server for db context: ~A" ircserver)
-      (dolist (nick-spec (cadr server-spec))
-        (log:debug "~&[[[ nick-spec:: ~A ]]]" nick-spec)
-	(let* ((nickname (car nick-spec))
-               (context-name nickname)
-               (channels (cadr nick-spec))
-               (channame (first channels))
-               (web-port (pop web-ports))
-               (web-server (web-server-name *bot-config*))
-               (web-uri-prefix "/"))
-          (log:debug "|||> WHAT IS THE CHANNEL? ~A" channels)
-          (log:debug "CONTEXT: IRC handle: ~A on channel:~A" nickname channels)
-          (when go?
-            (make-context-entry context-name ircserver channame web-server web-port web-uri-prefix :go? go?)
-            ))))))
-
-;; (loop with web-ports = (web-server-ports *bot-config*)
-;;       for instance in (irc-joins bstate)
-;;       for server = (first instance)
-;;       for joins = (rest instance)
-
-;;       ;; do (progn
-;;       ;;      (terpri) (print server) (terpri)
-;;       ;;      (print instance)
-;;       ;;      ;; (break)
-;;       ;;      )
-;;       when (listp joins)
-;;         do (loop for context in joins
-;;                  do (progn
-;;                       (format t "~2&<<< ~A~2%" context)
-;;                       (step)
-;;                       (let* ((chan-def (caadr context))
-;;                              (context-name (first chan-def))
-;;                              (channame (caadr chan-def))
-;;                              (web-server (web-server-name *bot-config*))
-;;                              ;; web-ports must match the number of channel joins.
-;;                              (web-port (pop web-ports))
-;;                              (web-uri-prefix "/"))
-;;                         ;; create the context entry for the given irc-join in *bot-config*
-;;                         (break)
-;;                         (make-context-entry context-name server channame web-server web-port web-uri-prefix :go? go?)))))
-
-(defun make-context-entry (bot-nick irc-server irc-channel web-server web-port uri-prefix &key (go? t))
-  "create a context entry in the database with the data in the lambdalist."
-  (with-connection (psql-botdb-credentials *bot-config*)
-    (if go?
-        (query (format nil "INSERT INTO contexts (
-                context_name,
-                irc_server,
-                irc_channel,
-                web_server,
-                web_port,
-                web_uri_prefix)
-VALUES ('~A', '~A', '~A', '~A', '~A', '~A');"
-                       bot-nick irc-server irc-channel web-server web-port uri-prefix))
-        (format nil "INSERT INTO contexts (
-                context_name,
-                irc_server,
-                irc_channel,
-                web_server,
-                web_port,
-                web_uri_prefix)
-VALUES ('~A', '~A', '~A', '~A', '~A', '~A');"
-                bot-nick irc-server irc-channel web-server web-port uri-prefix))))
+(defun load-contexts ()
+  "Upsert one contexts row per connection-spec in *BOT-CONFIG*.
+Idempotent — safe to call on every startup so the table stays in sync
+with the config without requiring manual SQL."
+  (with-connection (db-credentials *bot-config*)
+    (dolist (cs (connections *bot-config*))
+      (log:debug "~&CONTEXT: nick=~A server=~A channel=~A port=~A"
+                 (cs-nick cs) (cs-server cs) (cs-channel cs) (cs-web-port cs))
+      (make-context-entry
+       (cs-nick cs)
+       (cs-server cs)
+       (cs-channel cs)
+       (web-server-name *bot-config*)
+       (cs-web-port cs)
+       "/"))))
 
 (defun make-base-tables (sqlfile)
   "given the full path to a sql schema template 'SQLFILE for Harlie, fix
 the table ownership, and excecute the schema."
   (fix-bot-herder sqlfile)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (execute-file sqlfile)))
 
-(defun initialize-startup-maybe (&key  (go? nil))
+(defun initialize-startup-maybe (&key (go? nil))
   (let* ((db-schema (merge-pathnames *here-db* "bot-schema.sql")))
     (handler-case
-        (with-connection (psql-botdb-credentials *bot-config*)
-          (let* ((person (select-dao 'harlie-user)))
-            person))
+        (with-connection (db-credentials *bot-config*)
+          (select-dao 'harlie-user))
       (DATABASE-ERROR (e)
-        "In this event, the database does not exist, maybe. Try to create it,
-       and populate it."
-        (progn
-          (log:debug "Database probably hasn't been created.. ~A" e)
-          (log:info "Creating database to stand up the bot...")
-          (uiop:run-program (list "createdb" "botdb") :output t)
-          ;; (zero-users)
-          ;; harlie-users bot-channels channel-users
-          ;; (make-users)
-          (log:info "Creating tables for the various required users...")
-          (make-base-tables db-schema)
-          (load-contexts :bstate *bot-config* :go? t))))))
+        (log:debug "Database probably hasn't been created.. ~A" e)
+        (log:info "Creating database to stand up the bot...")
+        (uiop:run-program (list "createdb" "botdb") :output t)
+        (log:info "Creating tables for the various required users...")
+        (make-base-tables db-schema)))
+    ;; Sync contexts table from config on every startup.
+    (when go?
+      (load-contexts))))

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -34,9 +34,12 @@
    (mq-task :initform nil :accessor mq-task)
    (connection-state :initform :connecting :accessor connection-state
                      :documentation "Tracks registration lifecycle:
-:connecting -> :registered -> :identifying -> :joining -> :joined | :join-failed")
+:connecting -> :registered -> :identifying -> :joining -> :joined | :join-failed
+                              -> :registering --^  (when nick unregistered and email provided)")
    (nickserv-password :initform nil :accessor nickserv-password
-                      :documentation "NickServ password for IDENTIFY, or nil if not needed.")))
+                      :documentation "NickServ password for IDENTIFY/REGISTER, or nil if not needed.")
+   (nickserv-email    :initform nil :accessor nickserv-email
+                      :documentation "Email address for NickServ REGISTER. nil if not registering.")))
 
 (defclass bot-irc-channel (cl-irc:channel)
   ((trigger-list :initarg :trigger-list :initform nil :accessor trigger-list)
@@ -602,19 +605,53 @@ the JOIN is deferred further until NickServ acknowledges identification."
                         (log:info "~&[JOIN] ~A joining ~A on ~A" nickname channel ircserver)
                         (cl-irc:join connection channel :password channel-password)))))
 
-      ;; --- NickServ NOTICE: proceed to JOIN once identified ---
+      ;; --- NickServ NOTICE: identification, registration, and join sequencing ---
       (add-hook connection 'irc::irc-notice-message
                 (lambda (message)
                   (let ((sender (source message))
                         (text (car (last (arguments message)))))
-                    (when (and (string-equal sender "NickServ")
-                               (eq (connection-state connection) :identifying)
-                               (or (search "You are now identified" text)
-                                   (search "You are now logged in" text)))
-                      (setf (connection-state connection) :joining)
-                      (log:info "~&[NickServ] Identified. ~A joining ~A on ~A"
-                                nickname channel ircserver)
-                      (cl-irc:join connection channel :password channel-password)))))
+                    (when (string-equal sender "NickServ")
+                      (cond
+                        ;; Identification confirmed → join.
+                        ((and (eq (connection-state connection) :identifying)
+                              (or (search "You are now identified" text)
+                                  (search "You are now logged in" text)))
+                         (setf (connection-state connection) :joining)
+                         (log:info "~&[NickServ] Identified. ~A joining ~A on ~A"
+                                   nickname channel ircserver)
+                         (cl-irc:join connection channel :password channel-password))
+
+                        ;; Nick not registered → REGISTER if we have an email, else just join.
+                        ((and (eq (connection-state connection) :identifying)
+                              (search "not registered" text))
+                         (if (nickserv-email connection)
+                             (progn
+                               (setf (connection-state connection) :registering)
+                               (log:info "~&[NickServ] ~A not registered. Sending REGISTER to ~A."
+                                         nickname (nickserv-email connection))
+                               (privmsg connection "NickServ"
+                                        (format nil "REGISTER ~A ~A"
+                                                (nickserv-password connection)
+                                                (nickserv-email connection))))
+                             (progn
+                               (log:warn "~&[NickServ] ~A not registered and no email configured. Joining without identification."
+                                         nickname)
+                               (setf (connection-state connection) :joining)
+                               (cl-irc:join connection channel :password channel-password))))
+
+                        ;; Registration response received → log it and proceed to join.
+                        ;; The nick will be unverified until the user clicks the email link;
+                        ;; on the next restart IDENTIFY will work normally.
+                        ((eq (connection-state connection) :registering)
+                         (log:info "~&[NickServ] Registration response for ~A: ~A"
+                                   nickname text)
+                         (when (or (search "email" text)
+                                   (search "registered" text)
+                                   (search "activation" text))
+                           (log:info "~&[NickServ] ~A registered. Check ~A for activation link. Joining now."
+                                     nickname (nickserv-email connection))
+                           (setf (connection-state connection) :joining)
+                           (cl-irc:join connection channel :password channel-password))))))))
 
       ;; --- irc-join-message: send bot announcement only on our own join ---
       (add-hook connection 'irc::irc-join-message
@@ -669,10 +706,12 @@ the JOIN is deferred further until NickServ acknowledges identification."
 
       (read-message-loop connection))))
 
-(defun make-bot-connection (nickname ircserver connection-port &key nickserv-password)
+(defun make-bot-connection (nickname ircserver connection-port
+                            &key nickserv-password nickserv-email)
   "Make a connection to an IRC server.
-NICKSERV-PASSWORD, when non-nil, will be used to IDENTIFY with NickServ
-after registration before the channel JOIN is attempted."
+NICKSERV-PASSWORD, when non-nil, triggers a NickServ IDENTIFY after RPL_WELCOME.
+NICKSERV-EMAIL, when non-nil along with NICKSERV-PASSWORD, enables automatic
+REGISTER if the nick is not yet registered."
   (let ((connection (connect :nickname nickname
 			     :server ircserver
                              :port (if (eq connection-port :ssl)
@@ -684,6 +723,8 @@ after registration before the channel JOIN is attempted."
 			     :connection-type 'bot-irc-connection)))
     (when nickserv-password
       (setf (nickserv-password connection) nickserv-password))
+    (when nickserv-email
+      (setf (nickserv-email connection) nickserv-email))
     (setf (gethash
            (list (string-upcase ircserver)
                  (string-upcase nickname))
@@ -704,10 +745,11 @@ after registration before the channel JOIN is attempted."
 
 (defun start-threaded-irc-client-instance (ircserver connection-port nickname
                                             channel channel-key
-                                            &key nickserv-password)
+                                            &key nickserv-password nickserv-email)
   "Make a connection to an IRC server and spawn a thread to service it."
   (let ((connection (make-bot-connection nickname ircserver connection-port
-                                         :nickserv-password nickserv-password)))
+                                         :nickserv-password nickserv-password
+                                         :nickserv-email nickserv-email)))
     (make-thread
      (make-irc-client-instance-thunk nickname channel channel-key ircserver connection)
      :name (format nil "IRC Client thread: server ~A, nick ~A"
@@ -729,7 +771,8 @@ Connections are staggered by *INTER-CONNECTION-DELAY* seconds."
         (start-threaded-irc-client-instance
          (cs-server cs) connection-port (cs-nick cs)
          (cs-channel cs) (cs-channel-key cs)
-         :nickserv-password (cs-nickserv-password cs))
+         :nickserv-password (cs-nickserv-password cs)
+         :nickserv-email (cs-nickserv-email cs))
         (sleep *inter-connection-delay*)))))
 
 (defun print-bot-config (botconfig)

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -31,7 +31,12 @@
    (ignore-list :initform nil :accessor ignore-list) ;; vestigal, this slot isn't used.
    (message-q :initform (make-message-queue) :accessor message-q)
    ;;   (message-timer :initform nil :accessor message-timer)
-   (mq-task :initform nil :accessor mq-task)))
+   (mq-task :initform nil :accessor mq-task)
+   (connection-state :initform :connecting :accessor connection-state
+                     :documentation "Tracks registration lifecycle:
+:connecting -> :registered -> :identifying -> :joining -> :joined | :join-failed")
+   (nickserv-password :initform nil :accessor nickserv-password
+                      :documentation "NickServ password for IDENTIFY, or nil if not needed.")))
 
 (defclass bot-irc-channel (cl-irc:channel)
   ((trigger-list :initarg :trigger-list :initform nil :accessor trigger-list)
@@ -567,42 +572,107 @@ hook runs before the default-hook, extended here."
                                     (start-ignoring connection this-user-name channel))))))))))))))
 
 (defun make-irc-client-instance-thunk (nickname channels ircserver connection)
-  "Make the thunk which moves in and instantiates a new IRC connection."
-  (declare (ignorable nickname ircserver))
-  (lambda ()
-    (setf (bot-irc-client-thread connection) (bt:current-thread))
-    (log:debug "~2&Channels: ~A" channels)
+  "Make the thunk which moves in and instantiates a new IRC connection.
 
-    (if (listp channels)
-        (let ((ch (first channels))
-              (pass (second channels)))
-          (log:debug "||| Channel : ~A, Password: ~A |||~3%" ch pass)
-          (cl-irc:join connection ch :password pass)
-          (privmsg connection ch (format nil "NOTIFY:: Help, I'm a bot!")))
-        (progn
-          (log:debug "||| Channel (nopass) : ~A, Password: ~A |||~3%" channel nil)
-          (cl-irc:join connection channel)
-          (privmsg connection channel (format nil "NOTIFY:: Help, I'm a bot!"))))
-    
-    ;; (dolist (channel channels)
-    ;;   (log:debug "~2&Type of 'channel: ~A~3%" (type-of channel))
-    ;;   (log:debug "~&~S~3%" channel)
-    ;;   )
+Channel join is deferred until 001 RPL_WELCOME confirms registration.
+If NICKSERV-PASSWORD is set on the connection, IDENTIFY is sent first and
+the JOIN is deferred further until NickServ acknowledges identification."
+  (declare (ignorable ircserver))
+  (let ((channel (first channels))
+        (channel-password (second channels)))
+    (lambda ()
+      (setf (bot-irc-client-thread connection) (bt:current-thread))
+      (setf (connection-state connection) :connecting)
+      (log:info "~2&[CONNECT] nick=~A channel=~A server=~A" nickname channel ircserver)
 
-    ;; Protocol processing. server joins, messages, user tracking
-    (add-hook connection 'irc::irc-privmsg-message #'threaded-msg-hook)
-    (add-hook connection 'irc::ctcp-action-message #'threaded-action-hook)
-    (add-hook connection 'irc::irc-quit-message #'threaded-byebye-hook)
-    (add-hook connection 'irc::irc-part-message #'threaded-byebye-hook)
-    (add-hook connection 'irc::irc-notice-message #'notice-tracker)
-    (add-hook connection 'irc::irc-join-message #'user-join)
-    ;; (add-hook connection 'irc::irc-nick-message #'irc-nick-change)
-    ;; book-keeping hooks
-    (add-hook connection 'irc::irc-rpl_namreply-message #'channel-member-list-on-join)
-    (read-message-loop connection)))
+      ;; --- 001 RPL_WELCOME: registration confirmed, now identify or join ---
+      (add-hook connection 'irc::irc-rpl_welcome-message
+                (lambda (message)
+                  (declare (ignorable message))
+                  (setf (connection-state connection) :registered)
+                  (log:info "~&[001] Registered as ~A on ~A" nickname ircserver)
+                  (if (nickserv-password connection)
+                      (progn
+                        (setf (connection-state connection) :identifying)
+                        (log:info "~&[NickServ] Sending IDENTIFY for ~A" nickname)
+                        (privmsg connection "NickServ"
+                                 (format nil "IDENTIFY ~A" (nickserv-password connection))))
+                      (progn
+                        (setf (connection-state connection) :joining)
+                        (log:info "~&[JOIN] ~A joining ~A on ~A" nickname channel ircserver)
+                        (cl-irc:join connection channel :password channel-password)))))
 
-(defun make-bot-connection (nickname ircserver connection-port)
-  "Make a connection to an IRC server."
+      ;; --- NickServ NOTICE: proceed to JOIN once identified ---
+      (add-hook connection 'irc::irc-notice-message
+                (lambda (message)
+                  (let ((sender (source message))
+                        (text (car (last (arguments message)))))
+                    (when (and (string-equal sender "NickServ")
+                               (eq (connection-state connection) :identifying)
+                               (or (search "You are now identified" text)
+                                   (search "You are now logged in" text)))
+                      (setf (connection-state connection) :joining)
+                      (log:info "~&[NickServ] Identified. ~A joining ~A on ~A"
+                                nickname channel ircserver)
+                      (cl-irc:join connection channel :password channel-password)))))
+
+      ;; --- irc-join-message: send bot announcement only on our own join ---
+      (add-hook connection 'irc::irc-join-message
+                (lambda (message)
+                  (when (string-equal (source message) nickname)
+                    (let ((joined-channel (car (arguments message))))
+                      (setf (connection-state connection) :joined)
+                      (log:info "~&[JOINED] ~A is now in ~A on ~A"
+                                nickname joined-channel ircserver)
+                      (privmsg connection joined-channel *ignore-phrase*)))))
+
+      ;; --- JOIN error hooks: make failures visible in the log ---
+      (add-hook connection 'irc::irc-err_nosuchchannel-message
+                (lambda (message)
+                  (log:warn "~&[JOIN FAIL 403 no-such-channel] ~A ~A"
+                            channel (arguments message))
+                  (setf (connection-state connection) :join-failed)))
+
+      (add-hook connection 'irc::irc-err_toomanychannels-message
+                (lambda (message)
+                  (log:warn "~&[JOIN FAIL 405 too-many-channels] ~A ~A"
+                            channel (arguments message))
+                  (setf (connection-state connection) :join-failed)))
+
+      (add-hook connection 'irc::irc-err_inviteonlychan-message
+                (lambda (message)
+                  (log:warn "~&[JOIN FAIL 473 invite-only] ~A ~A"
+                            channel (arguments message))
+                  (setf (connection-state connection) :join-failed)))
+
+      (add-hook connection 'irc::irc-err_bannedfromchan-message
+                (lambda (message)
+                  (log:warn "~&[JOIN FAIL 474 banned] ~A ~A"
+                            channel (arguments message))
+                  (setf (connection-state connection) :join-failed)))
+
+      (add-hook connection 'irc::irc-err_badchannelkey-message
+                (lambda (message)
+                  (log:warn "~&[JOIN FAIL 475 bad-channel-key] ~A ~A"
+                            channel (arguments message))
+                  (setf (connection-state connection) :join-failed)))
+
+      ;; --- Protocol processing hooks ---
+      (add-hook connection 'irc::irc-privmsg-message #'threaded-msg-hook)
+      (add-hook connection 'irc::ctcp-action-message #'threaded-action-hook)
+      (add-hook connection 'irc::irc-quit-message #'threaded-byebye-hook)
+      (add-hook connection 'irc::irc-part-message #'threaded-byebye-hook)
+      (add-hook connection 'irc::irc-notice-message #'notice-tracker)
+      (add-hook connection 'irc::irc-join-message #'user-join)
+      ;; (add-hook connection 'irc::irc-nick-message #'irc-nick-change)
+      (add-hook connection 'irc::irc-rpl_namreply-message #'channel-member-list-on-join)
+
+      (read-message-loop connection))))
+
+(defun make-bot-connection (nickname ircserver connection-port &key nickserv-password)
+  "Make a connection to an IRC server.
+NICKSERV-PASSWORD, when non-nil, will be used to IDENTIFY with NickServ
+after registration before the channel JOIN is attempted."
   (let ((connection (connect :nickname nickname
 			     :server ircserver
                              :port (if (eq connection-port :ssl)
@@ -610,6 +680,8 @@ hook runs before the default-hook, extended here."
                                        :default)
                              :connection-security connection-port
 			     :connection-type 'bot-irc-connection)))
+    (when nickserv-password
+      (setf (nickserv-password connection) nickserv-password))
     (setf (gethash
            (list (string-upcase ircserver)
                  (string-upcase nickname))
@@ -628,9 +700,11 @@ hook runs before the default-hook, extended here."
       (bt:destroy-thread (bot-irc-client-thread connection))
       (remhash k *irc-connections*))))
 
-(defun start-threaded-irc-client-instance (ircserver connection-port nickname channels)
+(defun start-threaded-irc-client-instance (ircserver connection-port nickname channels
+                                            &key nickserv-password)
   "Make a connection to an IRC server and spawn a thread to service it."
-  (let ((connection (make-bot-connection nickname ircserver connection-port)))
+  (let ((connection (make-bot-connection nickname ircserver connection-port
+                                         :nickserv-password nickserv-password)))
     (make-thread
      (make-irc-client-instance-thunk nickname channels ircserver connection)
      :name (format nil "IRC Client thread: server ~A, nick ~A"
@@ -645,8 +719,14 @@ hook runs before the default-hook, extended here."
               (channels (cadr nick-spec)))
           (format t "Handle: ~A on channel: ~A ~%" nickname channels))))))
 
+(defparameter *inter-connection-delay* 2
+  "Seconds to wait between spawning IRC connection threads.
+Staggering prevents a burst of simultaneous TLS handshakes from
+triggering server-side flood protection.")
+
 (defun start-threaded-irc-client-instances (&key (go? nil))
-  "Spawn a thread to run a session with an IRC server."
+  "Spawn a thread to run a session with an IRC server.
+Connections are staggered by *INTER-CONNECTION-DELAY* seconds."
   (dolist (server-spec (irc-joins *bot-config*))
     (let* ((ircserver (caar server-spec))
            (connection-port (or (first (cdar server-spec))
@@ -654,12 +734,28 @@ hook runs before the default-hook, extended here."
       (log:debug "~&IRC Server for join: ~A ~A" ircserver connection-port)
       (dolist (nick-spec (cadr server-spec))
         (log:debug "~&[[[ nickspec for ~A: ~A ]]]" ircserver nick-spec)
-	(let ((nickname (car nick-spec))
-	      (channels (cadr nick-spec)))
-          (log:debug "IRC handle: ~A on channel:~A" nickname channels)
-          ;; (break)
+        (let ((nickname         (car nick-spec))
+              (channels         (cadr nick-spec))
+              (nickserv-password (caddr nick-spec)))
+          (log:debug "IRC handle: ~A on channel:~A nickserv:~A"
+                     nickname channels (if nickserv-password "<set>" nil))
           (when go?
-            (start-threaded-irc-client-instance ircserver connection-port nickname channels)))))))
+            (start-threaded-irc-client-instance ircserver connection-port nickname channels
+                                                :nickserv-password nickserv-password)
+            (sleep *inter-connection-delay*)))))))
+
+(defun test-connection-targets ()
+  (dolist (server-spec (irc-joins *bot-config*))
+    (format t "~2&<||| ~A |||>~2%" server-spec)
+    (let* ((ircserver (caar server-spec))
+           (connection-port (or (first (cdar server-spec))
+                                :default)))
+      (format t "IRC Server for join: ~A ~A" ircserver connection-port)
+      (dolist (nick-spec (cadr server-spec))
+        (format t "[|| The nick specification for ~A : ~A ||]" ircserver nick-spec)
+        (let ((nickname (car nick-spec))
+              (channels (cadr nick-spec)))
+          (format t "IRC handle: ~A on channel: ~A" nickname channels))))))
 
 (defun print-bot-config (botconfig)
   "print the contents of the bot's configuration class."

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -118,7 +118,7 @@ sender wasn't being ignored; true otherwise."))
   (setf (ignored channel/user-map) t)
   (log:info "~&MAKE-USER-IGNORED:: THIS-USER IS: ~A" this-user)
   (handler-case
-      (with-connection (psql-botdb-credentials *bot-config*)
+      (with-connection (db-credentials *bot-config*)
         ;; (update-dao this-user)
         (update-dao channel/user-map))
     (error (c)
@@ -132,7 +132,7 @@ sender wasn't being ignored; true otherwise."))
   (setf (ignored channel/user-map) nil)
   (log:info "~&MAKE-USER-UNIGNORED:: ~A / ~A~%" channel channel/user-map)
   (handler-case
-      (with-connection (psql-botdb-credentials *bot-config*)
+      (with-connection (db-credentials *bot-config*)
         (update-dao this-user)
         (update-dao channel/user-map))
     (error (c)
@@ -506,7 +506,7 @@ a specific user in a specific channel."))
       (setf (current-handle this-user) new-nick
             (prev-handle this-user) old-nick
             (last-seen this-user) (local-time:now))
-      (with-connection (psql-botdb-credentials *bot-config*)
+      (with-connection (db-credentials *bot-config*)
         (update-dao this-user)))))
 
 ;; (defun handle-swap (old new)
@@ -517,7 +517,7 @@ a specific user in a specific channel."))
 ;;     ;;            (list connection sender channel-name channel text token-text-list command))
 ;;     (setf (current-handle this-user) new-nick
 ;;           (prev-handle this-user) old-nick)
-;;     (with-connection (psql-botdb-credentials *bot-config*)
+;;     (with-connection (db-credentials *bot-config*)
 ;;       (update-dao this-user))))
 
 
@@ -571,15 +571,15 @@ hook runs before the default-hook, extended here."
                                   (when (ignored channel/user-map)
                                     (start-ignoring connection this-user-name channel))))))))))))))
 
-(defun make-irc-client-instance-thunk (nickname channels ircserver connection)
+(defun make-irc-client-instance-thunk (nickname channel channel-key ircserver connection)
   "Make the thunk which moves in and instantiates a new IRC connection.
 
+CHANNEL and CHANNEL-KEY are plain strings (or nil for no key).
 Channel join is deferred until 001 RPL_WELCOME confirms registration.
 If NICKSERV-PASSWORD is set on the connection, IDENTIFY is sent first and
 the JOIN is deferred further until NickServ acknowledges identification."
   (declare (ignorable ircserver))
-  (let ((channel (first channels))
-        (channel-password (second channels)))
+  (let ((channel-password channel-key))
     (lambda ()
       (setf (bot-irc-client-thread connection) (bt:current-thread))
       (setf (connection-state connection) :connecting)
@@ -700,24 +700,16 @@ after registration before the channel JOIN is attempted."
       (bt:destroy-thread (bot-irc-client-thread connection))
       (remhash k *irc-connections*))))
 
-(defun start-threaded-irc-client-instance (ircserver connection-port nickname channels
+(defun start-threaded-irc-client-instance (ircserver connection-port nickname
+                                            channel channel-key
                                             &key nickserv-password)
   "Make a connection to an IRC server and spawn a thread to service it."
   (let ((connection (make-bot-connection nickname ircserver connection-port
                                          :nickserv-password nickserv-password)))
     (make-thread
-     (make-irc-client-instance-thunk nickname channels ircserver connection)
+     (make-irc-client-instance-thunk nickname channel channel-key ircserver connection)
      :name (format nil "IRC Client thread: server ~A, nick ~A"
 		   ircserver nickname))))
-
-(defun test-conn-specs (con-specs)
-  (dolist (server-spec (irc-joins con-specs))
-    (let ((ircserver (car server-spec)))
-      (format t "Server for join: ~A~%" ircserver)
-      (dolist (nick-spec (cadr server-spec))
-        (let ((nickname (car nick-spec))
-              (channels (cadr nick-spec)))
-          (format t "Handle: ~A on channel: ~A ~%" nickname channels))))))
 
 (defparameter *inter-connection-delay* 2
   "Seconds to wait between spawning IRC connection threads.
@@ -727,45 +719,23 @@ triggering server-side flood protection.")
 (defun start-threaded-irc-client-instances (&key (go? nil))
   "Spawn a thread to run a session with an IRC server.
 Connections are staggered by *INTER-CONNECTION-DELAY* seconds."
-  (dolist (server-spec (irc-joins *bot-config*))
-    (let* ((ircserver (caar server-spec))
-           (connection-port (or (first (cdar server-spec))
-                                :default)))
-      (log:debug "~&IRC Server for join: ~A ~A" ircserver connection-port)
-      (dolist (nick-spec (cadr server-spec))
-        (log:debug "~&[[[ nickspec for ~A: ~A ]]]" ircserver nick-spec)
-        (let ((nickname         (car nick-spec))
-              (channels         (cadr nick-spec))
-              (nickserv-password (caddr nick-spec)))
-          (log:debug "IRC handle: ~A on channel:~A nickserv:~A"
-                     nickname channels (if nickserv-password "<set>" nil))
-          (when go?
-            (start-threaded-irc-client-instance ircserver connection-port nickname channels
-                                                :nickserv-password nickserv-password)
-            (sleep *inter-connection-delay*)))))))
-
-(defun test-connection-targets ()
-  (dolist (server-spec (irc-joins *bot-config*))
-    (format t "~2&<||| ~A |||>~2%" server-spec)
-    (let* ((ircserver (caar server-spec))
-           (connection-port (or (first (cdar server-spec))
-                                :default)))
-      (format t "IRC Server for join: ~A ~A" ircserver connection-port)
-      (dolist (nick-spec (cadr server-spec))
-        (format t "[|| The nick specification for ~A : ~A ||]" ircserver nick-spec)
-        (let ((nickname (car nick-spec))
-              (channels (cadr nick-spec)))
-          (format t "IRC handle: ~A on channel: ~A" nickname channels))))))
+  (dolist (cs (connections *bot-config*))
+    (let ((connection-port (if (cs-ssl cs) :ssl :default)))
+      (log:debug "~&IRC Server for join: ~A ~A nick=~A channel=~A"
+                 (cs-server cs) connection-port (cs-nick cs) (cs-channel cs))
+      (when go?
+        (start-threaded-irc-client-instance
+         (cs-server cs) connection-port (cs-nick cs)
+         (cs-channel cs) (cs-channel-key cs)
+         :nickserv-password (cs-nickserv-password cs))
+        (sleep *inter-connection-delay*)))))
 
 (defun print-bot-config (botconfig)
-  "print the contents of the bot's configuration class."
-  (dolist (server-spec (irc-joins botconfig))
-    (let* ((ircserver (caar server-spec))
-           (connection-kind (first (cdar server-spec))))
-      (dolist (nick-spec (cadr server-spec))
-	(let ((nickname (car nick-spec))
-	      (channels (cadr nick-spec)))
-	  (log:debug "~&~{~A~^~%~}~%~%" (list ircserver connection-kind nickname channels)))))))
+  "Print the connection specs in BOTCONFIG."
+  (dolist (cs (connections botconfig))
+    (log:debug "~&server=~A ssl=~A nick=~A channel=~A key=~A port=~A"
+               (cs-server cs) (cs-ssl cs) (cs-nick cs)
+               (cs-channel cs) (cs-channel-key cs) (cs-web-port cs))))
 
 (defun stop-threaded-irc-client-instances ()
   "Shut down a session with an IRC server, and clean up."

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -678,7 +678,9 @@ after registration before the channel JOIN is attempted."
                              :port (if (eq connection-port :ssl)
                                        6697
                                        :default)
-                             :connection-security connection-port
+                             :connection-security (if (eq connection-port :ssl)
+                                                      :ssl
+                                                      :none)
 			     :connection-type 'bot-irc-connection)))
     (when nickserv-password
       (setf (nickserv-password connection) nickserv-password))

--- a/url-store.lisp
+++ b/url-store.lisp
@@ -3,7 +3,10 @@
 (in-package #:harlie)
 
 (defclass postmodern-url-store ()
-  ((readwrite-url-db :initform (psql-botdb-credentials *bot-config*) :accessor readwrite-url-db)))
+  ((readwrite-url-db :initform nil :accessor readwrite-url-db)))
+
+(defmethod initialize-instance :after ((store postmodern-url-store) &key)
+  (setf (readwrite-url-db store) (db-credentials *bot-config*)))
 
 (defvar *the-url-store* (make-instance 'postmodern-url-store))
 

--- a/users.lisp
+++ b/users.lisp
@@ -20,7 +20,7 @@
   (:keys bot-channel-id))
 
 (defun make-bot-channel-aux (channel-name server-name)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (handler-case
         (let ((bco (car (select-dao 'bot-channel (:= :channel-name channel-name)))))
           (if bco
@@ -44,7 +44,7 @@
 
 (defun make-bot-channel (channel-name &optional (server-name nil))
   (log:debug "~2&Creating a channel object for channel: ~A~%" channel-name)
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let ((bco (make-bot-channel-aux channel-name server-name)))
       (log:debug "~2&TYPE OF BCO:[ ~S ] :: [ ~S ]~2%" (type-of bco) bco)
       
@@ -52,7 +52,7 @@
 
 (defun get-bot-channel-for-name (name &optional (server-name ""))
   "Given a NAME, return the associated BOT-CHANNEL object."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let ((c (make-bot-channel name server-name)))
       (values c))))
 
@@ -161,7 +161,7 @@ object and swap the old handle with the new one.
   (:documentation "given a channel object and a user object, return a mapping between them in the database."))
 
 (defmethod get-channel-user-mapping ((channel bot-channel) (user harlie-user))
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let ((c/u-map
             (select-dao 'channel-user (:and (:= 'channel-id (bot-channel-id channel))
                                             (:= 'user-id (harlie-user-id user))))))
@@ -180,7 +180,7 @@ object and swap the old handle with the new one.
 
 (defun get-user-for-id (id)
   "Given an ID of type integer, return the associated channel user handle."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let ((u (select-dao 'harlie-user  (:= 'harlie-user-id id))))
       (if (and (listp u) (>= (length u) 1))
           (first u)
@@ -188,7 +188,7 @@ object and swap the old handle with the new one.
 
 (defun get-user-for-handle (handle &key channel)
   "Given a HANDLE, return the user from the database, or create one."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (let ((this-user (or (first (select-dao 'harlie-user (:= 'harlie-user-name handle)))
                          (first (select-dao 'harlie-user (:= 'current-handle handle)))
                          (make-dao 'harlie-user :harlie-user-name handle
@@ -211,29 +211,29 @@ object and swap the old handle with the new one.
 
 (defun zero-bot-channels ()
   "Destroy and recreate the table to hold the channels the bot joins."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (drop-table "bot-channel" :if-exists t :cascade t)))
 
 (defun make-bot-channels ()
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (dao-table-definition 'bot-channel))))
 
 (defun zero-channel-users ()
   "destroy and recreate the table to hold a channel's persistent users."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (drop-table 'channel-user :if-exists t :cascade t)))
 
 (defun make-channel-users ()
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (dao-table-definition 'channel-user))))
 
 (defun zero-harlie-users ()
   "destroy the table that holds the users known to the bot."
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (drop-table "harlie-user" :if-exists t :cascade t)))
 
 (defun make-harlie-users ()
-  (with-connection (psql-botdb-credentials *bot-config*)
+  (with-connection (db-credentials *bot-config*)
     (query (dao-table-definition 'harlie-user))))
 
 (defun zero-users ()
@@ -263,7 +263,7 @@ object and swap the old handle with the new one.
 ;;     (upsert-dao this-user)))
 
 ;; (defun make-a-new-harlie-user (nick)
-;;   (with-connection (psql-botdb-credentials *bot-config*)
+;;   (with-connection (db-credentials *bot-config*)
 ;;     (let ((uobject (get-user-for-handle nick)))
 ;;       (if uobject
 ;;           (update-dao uobject)

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -166,26 +166,27 @@ or an error message, as appropriate."
   (push (create-folder-dispatcher-and-handler s (make-pathname-in-lisp-subdir p)) *dispatch-table*))
 
 (defun start-web-servers ()
-  "Initialize and start the web server subsystem."
+  "Initialize and start the web server subsystem.
+One acceptor is created and started per connection-spec in *BOT-CONFIG*."
   (setf clhs-lookup::*hyperspec-map-file*
 	(make-pathname-in-lisp-subdir "HyperSpec/Data/Map_Sym.txt"))
-  (dolist (port (web-server-ports *bot-config*))
-    (push (make-instance 'hunchentoot:easy-acceptor
-			 :port port
-			 :access-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-access.log")
-			 :message-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-error.log"))
-	  *acceptors*)
-    (glom-on-prefix "/" 'redirect-shortener-dispatch)
-    ;; (glom-on-prefix "/ass" 'url-index-ass-dispatch)
-    (glom-on-prefix "/ass/" 'ass-url-index)
-    (glom-on-static-file "/robots.txt" "harlie/robots.txt")
-    (glom-on-regex "^/help/?$" 'help-dispatch)
-    (glom-on-regex "^/source" 'source-dispatch)
-    (glom-on-regex "^/hyper(spec)?/?$" 'hyperspec-base-dispatch)
-    (glom-on-folder "/HyperSpec/" "HyperSpec/")
-    (glom-on-folder "/gitrepo/" "harlie/.git/")
-    (glom-on-prefix "/harlie.git" 'gitrepo-base-dispatch)
-    (start (car *acceptors*))))
+  (glom-on-prefix "/" 'redirect-shortener-dispatch)
+  ;; (glom-on-prefix "/ass" 'url-index-ass-dispatch)
+  (glom-on-prefix "/ass/" 'ass-url-index)
+  (glom-on-static-file "/robots.txt" "harlie/robots.txt")
+  (glom-on-regex "^/help/?$" 'help-dispatch)
+  (glom-on-regex "^/source" 'source-dispatch)
+  (glom-on-regex "^/hyper(spec)?/?$" 'hyperspec-base-dispatch)
+  (glom-on-folder "/HyperSpec/" "HyperSpec/")
+  (glom-on-folder "/gitrepo/" "harlie/.git/")
+  (glom-on-prefix "/harlie.git" 'gitrepo-base-dispatch)
+  (dolist (cs (connections *bot-config*))
+    (let ((acceptor (make-instance 'hunchentoot:easy-acceptor
+                                   :port (cs-web-port cs)
+                                   :access-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-access.log")
+                                   :message-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-error.log"))))
+      (push acceptor *acceptors*)
+      (start acceptor))))
 
 (defun stop-web-servers ()
   "Shut down the web server subsystem."


### PR DESCRIPTION
## Summary

- Replaces the monolithic 13-slot `config` class with a flat `connection-spec` + 3-slot `config` pair, eliminating the positional coupling between nick, channel, and web port that made multi-server configs fragile
- Implements a deterministic, event-driven IRC connection state machine (`:connecting → :registered → :identifying → :joining → :joined`) that defers channel JOIN until RPL_WELCOME is received, with NickServ IDENTIFY before JOIN when a password is configured
- Adds automatic NickServ REGISTER flow for unregistered nicks: when `:nickserv-password` and `:nickserv-email` are both set and NickServ reports the nick as unregistered, the bot registers it and proceeds to join; subsequent restarts will IDENTIFY normally
- Credentials are read from environment variables via `uiop:getenv` rather than stored as literals in config files
- Fixes a `SIMPLE-TYPE-ERROR` at the BSD socket layer caused by passing `:default` as `:connection-security` to `cl-irc:connect`; only `:none` or `:ssl` are valid
- `load-contexts` is now idempotent (upsert on every startup); no manual SQL needed to add or change channels
- Manual.org added covering acceptance testing, database init, channel addition, NickServ flow, and legacy migration

## Test plan

- [x] Start the bot with a fresh config using the new `make-connection-spec` / `make-config` constructors; verify all connections come up
- [x] Confirm NickServ IDENTIFY succeeds for a registered nick before JOIN
- [x] Confirm REGISTER is attempted for an unregistered nick when `:nickserv-email` is set, and that JOIN proceeds after the registration response
- [x] Confirm that a connection without `:nickserv-password` joins directly without contacting NickServ
- [x] Verify `load-contexts` upsert is idempotent across two consecutive restarts (no duplicate rows, no errors)
- [x] Verify SSL and non-SSL connections both establish correctly

🄯 Brian O'Reilly <fade@deepsky.com>, 2026