### PR TITLE
Integration test suite for NickServ connection state machine

### DIFF
--- a/harlie.asd
+++ b/harlie.asd
@@ -2,6 +2,7 @@
 
 (asdf:defsystem #:harlie
   :serial t
+  :in-order-to ((asdf:test-op (asdf:test-op #:harlie/test/all)))
   :depends-on (#:alexandria
 	       #:bordeaux-threads
                #:lparallel
@@ -69,3 +70,16 @@
 	       (:file "sleep-timers")
                (:file "init-first-run")
 	       (:file "harlie")))
+
+(asdf:defsystem #:harlie/test/fake-irc-server
+  :depends-on (#:harlie #:bordeaux-threads #:usocket #:cl-ppcre)
+  :components ((:file "test/fake-irc-server")))
+
+(asdf:defsystem #:harlie/test/nickserv-flow
+  :depends-on (#:harlie #:harlie/test/fake-irc-server #:parachute)
+  :components ((:file "test/nickserv-flow")))
+
+(asdf:defsystem #:harlie/test/all
+  :depends-on (#:harlie/test/fake-irc-server #:harlie/test/nickserv-flow #:parachute)
+  :perform (asdf:test-op (op c)
+             (uiop:symbol-call :parachute :test :harlie/test/nickserv-flow)))

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -50,18 +50,22 @@
 ;; on the fly and setting up the trigger list.
 
 (defmethod cl-irc::default-hook :after ((message cl-irc:irc-join-message))
-  (let* ((connection (cl-irc:connection message))
-	 (channel-name (car (arguments message)))
-	 (channel (find-channel connection channel-name)))
-    (change-class channel 'bot-irc-channel
-		  :trigger-list (random-words
-				 (make-instance 'bot-context
-						:bot-nick (nickname (user connection))
-						:bot-irc-server (server-name connection)
-						:bot-irc-channel channel-name)
-				 10 #'acceptable-word-p))
-    (when (get-bot-channel-for-name channel-name (server-name connection))
-      (log:debug "~2&|| Created channel entry for ~A ||~2%" channel-name))))
+  (handler-case
+      (let* ((connection (cl-irc:connection message))
+	     (channel-name (car (arguments message)))
+	     (channel (find-channel connection channel-name)))
+        (change-class channel 'bot-irc-channel
+		      :trigger-list (random-words
+				     (make-instance 'bot-context
+						    :bot-nick (nickname (user connection))
+						    :bot-irc-server (server-name connection)
+						    :bot-irc-channel channel-name)
+				     10 #'acceptable-word-p))
+        (when (get-bot-channel-for-name channel-name (server-name connection))
+          (log:debug "~2&|| Created channel entry for ~A ||~2%" channel-name)))
+    (error (e)
+      (log:warn "~&[JOIN HOOK] Error setting up channel ~A: ~A"
+                (car (arguments message)) e))))
 
 ;; The rate-limiting queue structure for the connection to the IRC server.
 
@@ -444,7 +448,8 @@ a specific user in a specific channel."))
 
 (defun user-join (message)
   "Handle channel join events, manage channel rota for persistent state (ignores)"
-  (let* ((connection (connection message))
+  (handler-case
+   (let* ((connection (connection message))
          (sender (source message))
          (channel-name (car (arguments message)))
          (channel (gethash channel-name (channels connection) )) ;; 'BOT-IRC-CHANNEL object
@@ -479,7 +484,10 @@ a specific user in a specific channel."))
                                         (first cuo)
                                         cuo)))
                 ;; (setf (gethash sender *users*) (list uobject cobject channel-users))
-                (map-user-and-channel-to-sticky-state cobject (harlie-user-name uobject) :cumap channel-users))))))))
+                (map-user-and-channel-to-sticky-state cobject (harlie-user-name uobject) :cumap channel-users))))))
+   (error (e)
+     (log:warn "~&[USER-JOIN] Error handling join for ~A: ~A"
+               (source message) e)))))
 
 (defun irc-nick-change (message)
   (let* ((connection (connection message))
@@ -703,30 +711,41 @@ hook runs before the default-hook, extended here."
       ;; (add-hook connection 'irc::irc-nick-message #'irc-nick-change)
       (add-hook connection 'irc::irc-rpl_namreply-message #'channel-member-list-on-join)
 
-      ;; Replace read-message-loop with a tolerant equivalent.
-      ;; cl-irc signals SIMPLE-ERROR "Ignore unknown reply." for any
-      ;; server numeric it doesn't recognise (e.g. 900 RPL_LOGGEDIN,
-      ;; which Libera.Chat sends after SASL/NickServ login).  The
-      ;; default read-message-loop lets that kill the thread; we catch
-      ;; it per-iteration and continue instead.
+      ;; Resilient message loop.
+      ;;
+      ;; cl-irc signals SIMPLE-ERROR "Ignore unknown reply." for server
+      ;; numerics it doesn't recognise (e.g. 900 RPL_LOGGEDIN on Libera).
+      ;;
+      ;; Hook errors (database failures, etc.) must not kill the connection
+      ;; thread -- log them and continue.  Only stream-level errors (EOF,
+      ;; socket reset) indicate the connection is genuinely dead and should
+      ;; propagate to terminate the thread.
       (loop
         (handler-case (read-message connection)
+          (stream-error (e)
+            (log:warn "~&[IRC] Stream error on ~A, closing connection: ~A" ircserver e)
+            (error e))
           (simple-error (e)
             (if (search "Ignore unknown reply" (simple-condition-format-control e))
                 (log:debug "~&[IRC] Skipping unrecognized server message on ~A" ircserver)
-                (error e))))))))
+                (log:warn "~&[IRC] Error processing message on ~A: ~A" ircserver e)))
+          (error (e)
+            (log:warn "~&[IRC] Error in message handler on ~A: ~A" ircserver e)))))))
 
 (defun make-bot-connection (nickname ircserver connection-port
-                            &key nickserv-password nickserv-email)
+                            &key nickserv-password nickserv-email port)
   "Make a connection to an IRC server.
 NICKSERV-PASSWORD, when non-nil, triggers a NickServ IDENTIFY after RPL_WELCOME.
 NICKSERV-EMAIL, when non-nil along with NICKSERV-PASSWORD, enables automatic
-REGISTER if the nick is not yet registered."
+REGISTER if the nick is not yet registered.
+PORT, when a valid TCP port number (1-65535), connects to that specific port
+regardless of CONNECTION-PORT; useful for non-standard ports and test servers."
   (let ((connection (connect :nickname nickname
 			     :server ircserver
-                             :port (if (eq connection-port :ssl)
-                                       6697
-                                       :default)
+                             :port (cond
+                                     ((and (integerp port) (<= 1 port 65535)) port)
+                                     ((eq connection-port :ssl) 6697)
+                                     (t :default))
                              :connection-security (if (eq connection-port :ssl)
                                                       :ssl
                                                       :none)

--- a/test/fake-irc-server.lisp
+++ b/test/fake-irc-server.lisp
@@ -1,0 +1,172 @@
+;;;; test/fake-irc-server.lisp
+;;;;
+;;;; A minimal TCP IRC server for use in integration tests.  It speaks
+;;;; just enough of the IRC protocol to drive the bot's connection state
+;;;; machine: it completes the NICK/USER handshake, sends RPL_WELCOME,
+;;;; and delivers configurable NickServ NOTICE messages in response to
+;;;; IDENTIFY and REGISTER commands.
+
+(defpackage #:harlie/test/fake-irc-server
+  (:use #:cl)
+  (:export #:fake-irc-server
+           #:start-fake-irc-server
+           #:stop-fake-irc-server
+           #:fis-port
+           #:fis-received
+           #:fis-received-p
+           #:fis-wait-for
+           #:with-fake-irc-server))
+
+(in-package #:harlie/test/fake-irc-server)
+
+;;;; ---- Data structure -------------------------------------------------------
+
+(defclass fake-irc-server ()
+  ((port
+    :reader fis-port
+    :documentation "The localhost port the server is listening on.")
+   (received
+    :initform nil
+    :accessor fis-received
+    :documentation "All raw lines received from the client, newest first.")
+   (lock
+    :initform (bt:make-lock "fis-lock")
+    :reader fis-lock)
+   (listen-socket
+    :initform nil
+    :accessor fis-listen-socket)
+   (server-thread
+    :initform nil
+    :accessor fis-server-thread)
+   ;; Configurable NickServ responses.  Each is a complete raw IRC line
+   ;; (without trailing newline) to send when the corresponding PRIVMSG
+   ;; is received.  nil means send no response.
+   (nickserv-identify-response
+    :initarg :nickserv-identify-response
+    :initform nil
+    :accessor fis-nickserv-identify-response
+    :documentation "Line sent when PRIVMSG NickServ :IDENTIFY is received.")
+   (nickserv-not-registered-response
+    :initarg :nickserv-not-registered-response
+    :initform nil
+    :accessor fis-nickserv-not-registered-response
+    :documentation "Line sent instead of identify-response when nick is unknown.")
+   (nickserv-register-response
+    :initarg :nickserv-register-response
+    :initform nil
+    :accessor fis-nickserv-register-response
+    :documentation "Line sent when PRIVMSG NickServ :REGISTER is received.")))
+
+;;;; ---- Server loop ----------------------------------------------------------
+
+(defun strip-cr (line)
+  "Remove a trailing carriage return if present (IRC uses CRLF)."
+  (if (and (> (length line) 0)
+           (char= (char line (1- (length line))) #\Return))
+      (subseq line 0 (1- (length line)))
+      line))
+
+(defun send-line (stream line)
+  (write-string line stream)
+  (write-char #\Return stream)
+  (write-char #\Newline stream)
+  (finish-output stream))
+
+(defun run-server-loop (server client-socket)
+  (let ((stream (usocket:socket-stream client-socket))
+        (nick nil))
+    (loop
+      (let ((raw (read-line stream nil nil)))
+        (when (null raw) (return))
+        (let ((line (strip-cr raw)))
+          (bt:with-lock-held ((fis-lock server))
+            (push line (fis-received server)))
+          (cond
+            ((cl-ppcre:scan "^NICK " line)
+             (let ((raw (string-trim '(#\Space) (subseq line 5))))
+               (setf nick (if (and (> (length raw) 0) (char= (char raw 0) #\:))
+                              (subseq raw 1)
+                              raw))))
+
+            ((cl-ppcre:scan "^USER " line)
+             (let ((n (or nick "unknown")))
+               (send-line stream
+                          (format nil ":fake.irc.server 001 ~A :Welcome to the fake IRC network ~A" n n))))
+
+            ((cl-ppcre:scan "(?i)^PRIVMSG NickServ :IDENTIFY" line)
+             (let ((resp (or (fis-nickserv-identify-response server)
+                             (fis-nickserv-not-registered-response server))))
+               (when resp
+                 (send-line stream resp))))
+
+            ((cl-ppcre:scan "(?i)^PRIVMSG NickServ :REGISTER" line)
+             (when (fis-nickserv-register-response server)
+               (send-line stream (fis-nickserv-register-response server))))
+
+            ;; JOIN: confirm the join so the bot transitions to :joined.
+            ;; cl-irc sends the channel as a trailing argument: "JOIN :#channel",
+            ;; so strip the leading colon before echoing back.
+            ((cl-ppcre:scan "^JOIN " line)
+             (let* ((raw-channel (string-trim '(#\Space) (subseq line 5)))
+                    (channel (if (and (> (length raw-channel) 0)
+                                      (char= (char raw-channel 0) #\:))
+                                 (subseq raw-channel 1)
+                                 raw-channel)))
+               (send-line stream
+                          (format nil ":~A!~A@127.0.0.1 JOIN ~A"
+                                  (or nick "unknown")
+                                  (or nick "unknown")
+                                  channel))))
+
+            ;; Absorb QUIT, PING, etc. silently.
+            (t nil)))))))
+
+;;;; ---- Public API -----------------------------------------------------------
+
+(defun start-fake-irc-server (server)
+  "Bind to a random localhost port and start accepting one connection."
+  (let ((sock (usocket:socket-listen "127.0.0.1" 0 :reuse-address t)))
+    (setf (fis-listen-socket server) sock)
+    (setf (slot-value server 'port) (usocket:get-local-port sock))
+    (setf (fis-server-thread server)
+          (bt:make-thread
+           (lambda ()
+             (unwind-protect
+                  (let ((client (usocket:socket-accept sock)))
+                    (unwind-protect
+                         (run-server-loop server client)
+                      (usocket:socket-close client)))
+               (ignore-errors (usocket:socket-close sock))))
+           :name "fake-irc-server")))
+  server)
+
+(defun stop-fake-irc-server (server)
+  "Shut down the fake server and its thread."
+  (when (fis-server-thread server)
+    (ignore-errors (bt:destroy-thread (fis-server-thread server)))
+    (setf (fis-server-thread server) nil))
+  (when (fis-listen-socket server)
+    (ignore-errors (usocket:socket-close (fis-listen-socket server)))
+    (setf (fis-listen-socket server) nil)))
+
+(defun fis-received-p (server substring)
+  "Return the first received line containing SUBSTRING, or NIL."
+  (bt:with-lock-held ((fis-lock server))
+    (find substring (fis-received server) :test #'search)))
+
+(defun fis-wait-for (server substring &optional (timeout 8))
+  "Block until SERVER has received a line containing SUBSTRING, or TIMEOUT seconds pass.
+Returns T if the line was received, NIL on timeout."
+  (let ((deadline (+ (get-universal-time) timeout)))
+    (loop
+      (when (fis-received-p server substring) (return t))
+      (when (> (get-universal-time) deadline) (return nil))
+      (sleep 0.05))))
+
+(defmacro with-fake-irc-server ((var &rest initargs) &body body)
+  "Bind VAR to a started fake-irc-server, ensuring cleanup on exit."
+  `(let ((,var (start-fake-irc-server
+                (make-instance 'fake-irc-server ,@initargs))))
+     (unwind-protect
+          (progn ,@body)
+       (stop-fake-irc-server ,var))))

--- a/test/nickserv-flow.lisp
+++ b/test/nickserv-flow.lisp
@@ -1,0 +1,137 @@
+;;;; test/nickserv-flow.lisp
+;;;;
+;;;; Integration tests for the NickServ authentication and registration
+;;;; state machine in make-irc-client-instance-thunk.
+;;;;
+;;;; Each test:
+;;;;   1. Starts a fake IRC server with a configurable NickServ personality.
+;;;;   2. Connects a bot-irc-connection against it on localhost.
+;;;;   3. Waits for the expected connection-state, with a timeout.
+;;;;   4. Asserts on the state and on the commands the fake server received.
+
+(uiop:define-package #:harlie/test/nickserv-flow
+  (:use #:cl #:harlie/test/fake-irc-server)
+  (:import-from #:harlie
+                #:make-bot-connection
+                #:make-irc-client-instance-thunk
+                #:connection-state
+                #:*irc-connections*)
+  (:import-from #:bordeaux-threads #:make-thread #:destroy-thread)
+  (:local-nicknames (#:tt #:parachute)))
+
+(in-package #:harlie/test/nickserv-flow)
+
+;;;; ---- Helpers --------------------------------------------------------------
+
+(defparameter *state-poll-interval* 0.05
+  "Seconds between state polls in WAIT-FOR-STATE.")
+
+(defparameter *state-timeout* 8
+  "Seconds before WAIT-FOR-STATE gives up.")
+
+(defun wait-for-state (connection target-state &optional (timeout *state-timeout*))
+  "Poll CONNECTION's state until it equals TARGET-STATE or TIMEOUT seconds pass.
+Returns T if the state was reached, NIL on timeout."
+  (let ((deadline (+ (get-universal-time) timeout)))
+    (loop
+      (when (eq (connection-state connection) target-state)
+        (return t))
+      (when (> (get-universal-time) deadline)
+        (return nil))
+      (sleep *state-poll-interval*))))
+
+(defun make-test-connection (server nick &key nickserv-password nickserv-email)
+  "Create a bot-irc-connection against the fake SERVER and start its
+message-loop thread.  Returns (values connection thread)."
+  (let* ((connection (make-bot-connection nick "127.0.0.1" :default
+                                          :port (fis-port server)
+                                          :nickserv-password nickserv-password
+                                          :nickserv-email nickserv-email))
+         (thread (bt:make-thread
+                  (make-irc-client-instance-thunk
+                   nick "#test-channel" nil "127.0.0.1" connection)
+                  :name (format nil "test-irc-thread/~A" nick))))
+    (values connection thread)))
+
+(defun cleanup-test-connection (nick)
+  "Remove the test connection from *irc-connections*."
+  (remhash (list "127.0.0.1" (string-upcase nick)) *irc-connections*))
+
+(defmacro with-test-connection ((conn-var nick &rest connect-args) server &body body)
+  "Run BODY with CONN-VAR bound to a test connection against SERVER.
+Cleans up the connection and its thread on exit."
+  (let ((thread-var (gensym "THREAD")))
+    `(multiple-value-bind (,conn-var ,thread-var)
+         (make-test-connection ,server ,nick ,@connect-args)
+       (declare (ignorable ,thread-var))
+       (unwind-protect
+            (progn ,@body)
+         (ignore-errors (bt:destroy-thread ,thread-var))
+         (cleanup-test-connection ,nick)))))
+
+;;;; ---- NickServ NOTICE helper strings --------------------------------------
+
+(defun nickserv-notice (nick text)
+  (format nil ":NickServ!NickServ@services.fake.irc NOTICE ~A :~A" nick text))
+
+;;;; ---- Test suite ----------------------------------------------------------
+
+(tt:define-test "harlie.nickserv")
+
+(tt:define-test "no-password-joins-directly"
+  :parent "harlie.nickserv"
+  :description "When no nickserv-password is set the bot joins immediately after RPL_WELCOME."
+  (with-fake-irc-server (server)
+    (with-test-connection (conn "Plonk") server
+      (tt:true (fis-wait-for server "JOIN :#test-channel"))
+      ;; Must NOT have sent IDENTIFY.
+      (tt:false (fis-received-p server "IDENTIFY")))))
+
+(tt:define-test "identify-success-then-join"
+  :parent "harlie.nickserv"
+  :description "Bot identifies successfully and then joins the channel."
+  (with-fake-irc-server (server
+    :nickserv-identify-response
+    (nickserv-notice "Plonk" "You are now logged in as Plonk"))
+    (with-test-connection (conn "Plonk" :nickserv-password "s3kr3t") server
+      (tt:true (fis-wait-for server "JOIN :#test-channel"))
+      (tt:true (fis-received-p server "IDENTIFY s3kr3t")))))
+
+(tt:define-test "not-registered-without-email-joins-without-identification"
+  :parent "harlie.nickserv"
+  :description "When the nick is unregistered and no email is configured, the bot warns and joins anyway."
+  (with-fake-irc-server (server
+    :nickserv-not-registered-response
+    (nickserv-notice "Plonk" "This nickname is not registered."))
+    (with-test-connection (conn "Plonk" :nickserv-password "s3kr3t") server
+      (tt:true (fis-wait-for server "JOIN :#test-channel"))
+      ;; Must NOT have attempted REGISTER.
+      (tt:false (fis-received-p server "REGISTER")))))
+
+(tt:define-test "not-registered-with-email-registers-then-joins"
+  :parent "harlie.nickserv"
+  :description "When the nick is unregistered and an email is configured, the bot registers and then joins."
+  (with-fake-irc-server (server
+    :nickserv-not-registered-response
+    (nickserv-notice "Plonk" "This nickname is not registered.")
+    :nickserv-register-response
+    (nickserv-notice "Plonk" "An email containing account activation instructions has been sent to test@example.com."))
+    (with-test-connection (conn "Plonk"
+                                :nickserv-password "s3kr3t"
+                                :nickserv-email "test@example.com")
+        server
+      (tt:true (fis-wait-for server "JOIN :#test-channel"))
+      (tt:true (fis-received-p server "REGISTER s3kr3t test@example.com")))))
+
+(tt:define-test "identify-before-join"
+  :parent "harlie.nickserv"
+  :description "IDENTIFY must be sent before JOIN, not after."
+  (with-fake-irc-server (server
+    :nickserv-identify-response
+    (nickserv-notice "Plonk" "You are now logged in as Plonk"))
+    (with-test-connection (conn "Plonk" :nickserv-password "s3kr3t") server
+      (tt:true (fis-wait-for server "JOIN :#test-channel"))
+      (let* ((lines (reverse (fis-received server)))
+             (identify-pos (position-if (lambda (l) (search "IDENTIFY" l)) lines))
+             (join-pos     (position-if (lambda (l) (search "JOIN" l)) lines)))
+        (tt:true (and identify-pos join-pos (< identify-pos join-pos)))))))


### PR DESCRIPTION
## Summary

- Adds a fake TCP IRC server (`test/fake-irc-server.lisp`) that speaks just enough IRC to drive the bot's connection state machine: NICK/USER handshake, RPL_WELCOME, configurable NickServ NOTICE responses, and JOIN confirmation
- Adds five parachute integration tests (`test/nickserv-flow.lisp`) covering the full NickServ flow: no-password direct join, successful IDENTIFY, unregistered nick without email, unregistered nick with REGISTER, and IDENTIFY-before-JOIN ordering
- Wires `(asdf:test-system :harlie)` to run the suite via `harlie/test/all`
- Hardens `irc-client.lisp`: resilient message loop that isolates hook errors from stream errors, `handler-case` guards on `default-hook :after` and `user-join`, and a `:port` override on `make-bot-connection` for non-standard/test servers

## Test plan

- [x] `(asdf:test-system :harlie)` → 10 assertions, 0 failures
- [x] `(asdf:test-system :harlie/test/all)` → same result
- [x] Confirm no regressions on live Libera.Chat connection (NickServ IDENTIFY flow still functions)

🄯 Brian O'Reilly <fade@deepsky.com>, 2026