### PR TITLE
Integrate test suite and documentation

### DIFF
--- a/Manual.org
+++ b/Manual.org
@@ -211,3 +211,163 @@ git checkout unfuck_configuration_and_state
 ~load-contexts~ will sync the ~contexts~ table from the config on every
 subsequent startup — no further manual SQL is ever needed to add or
 change channels.
+
+* Testing
+
+** Overview
+
+Harlie's test suite is divided into three layers, each packaged as a
+separate ASDF sub-system under ~harlie.asd~.  All layers are wired to
+~(asdf:test-system :harlie)~ via the ~:in-order-to~ clause on the base
+system.
+
+| Sub-system                    | What it tests                                   |
+|-------------------------------+-------------------------------------------------|
+| ~harlie/test/unit~            | Pure functions: URL extraction, name-detector, config constructors |
+| ~harlie/test/db~              | DAO operations against a real database           |
+| ~harlie/test/nickserv-flow~   | Full IRC connection and NickServ state machine   |
+
+The test runner is [[https://shinmera.github.io/parachute/][Parachute]].
+
+** Prerequisites: the test database
+
+Database integration tests connect to a separate ~harlie-test~ database.
+Create it once:
+
+#+begin_src sh
+createdb harlie-test
+pg_dump botdb --schema-only | psql harlie-test
+#+end_src
+
+The production ~botdb~ database is never touched by the test suite.  Each
+test that writes rows cleans up after itself using ~unwind-protect~, so
+the suite is fully idempotent and can be re-run without resetting the schema.
+
+** Running the suite
+
+#+begin_src lisp
+(asdf:test-system :harlie)
+#+end_src
+
+Or to run a single layer interactively:
+
+#+begin_src lisp
+(asdf:load-system :harlie/test/unit)
+(parachute:test :harlie/test/unit/urls)
+
+(asdf:load-system :harlie/test/db)
+(parachute:test :harlie/test/db/users)
+
+(asdf:load-system :harlie/test/nickserv-flow)
+(parachute:test :harlie/test/nickserv-flow)
+#+end_src
+
+** Unit tests (~test/unit/~)
+
+These tests exercise pure functions that require no database or network.
+
+- ~test/unit/urls.lisp~ — ~extract-urls~ (http, https, www-prefixed, multiple
+  URLs per line, none, empty input) and ~de-utm-url~ (strips UTM tracking
+  parameters and other noise from URLs).
+
+- ~test/unit/triggers.lisp~ — ~make-name-detector~: verifies exact-match,
+  case-insensitivity, tolerance of surrounding punctuation, and correct
+  non-match for substrings embedded inside longer words.
+
+- ~test/unit/config.lisp~ — ~make-connection-spec~: required fields are
+  stored correctly, optional fields default to ~nil~, and explicit optional
+  values round-trip cleanly.
+
+** Database integration tests (~test/db/~)
+
+These tests call the real DAO functions against ~harlie-test~.  They are
+split across two files, both sharing the fixture defined in
+~test/db/package.lisp~.
+
+*** The ~with-test-db~ fixture
+
+~with-test-db~ is a macro that:
+
+1. Rebinds ~*bot-config*~ to a minimal config whose ~:db-credentials~ point
+   at ~harlie-test~.  The database username is taken from the ~$USER~
+   environment variable — no hardcoded credentials.
+
+2. Opens a ~postmodern:with-connection~ to that database, so the rest of the
+   body runs inside a live connection.
+
+Because all DAO helpers internally call ~(with-connection (db-credentials
+*bot-config*) ...)~, the rebinding is enough to redirect every database
+call made by the code under test.
+
+A one-time call to ~ensure-dao-classes-finalized~ runs at package load
+time.  Postmodern generates per-class methods (~insert-dao~, ~update-dao~,
+etc.) lazily via MOP ~finalize-inheritance~, but SBCL does not finalize
+DAO classes at ~defclass~ time.  Without explicit finalization the methods
+do not exist and the tests fail with "no applicable method for
+~insert-dao~".  Calling ~closer-mop:finalize-inheritance~ once per class
+at load time — guarded by ~class-finalized-p~ — generates the methods
+without producing redefinition warnings on subsequent runs.
+
+*** ~test/db/contexts.lisp~
+
+Tests for ~make-context-entry~ and ~load-contexts~:
+
+- Fresh insert creates exactly one row.
+- Calling ~make-context-entry~ twice for the same key leaves exactly one row
+  (idempotent).
+- Re-inserting with a different ~web-port~ updates the existing row in place.
+- ~load-contexts~ inserts one row per ~connection-spec~ in ~*bot-config*~.
+- Calling ~load-contexts~ twice still leaves exactly one row per spec.
+
+Each test deletes its rows in the ~unwind-protect~ cleanup form so the
+suite stays idempotent across runs.
+
+*** ~test/db/users.lisp~
+
+Tests for the three user-related DAO helpers:
+
+- ~make-bot-channel~ creates a ~bot-channel~ row and returns a DAO object;
+  a second call with the same name returns the same row (same ID).
+
+- ~get-user-for-handle~ creates a ~harlie-user~ row if none exists and
+  returns a DAO object; a second call returns the same row.
+
+- ~get-channel-user-mapping~ creates the join-table row linking a
+  ~bot-channel~ to a ~harlie-user~, with ~ignored~ defaulting to false;
+  a second call returns the same row.
+
+** NickServ flow tests (~test/nickserv-flow.lisp~)
+
+These tests spin up a fake IRC server (a plain TCP listener in
+~test/fake-irc-server.lisp~) in a background thread, connect a real bot
+instance to it, and drive it through the NickServ authentication state
+machine end-to-end.
+
+The fake server handles:
+
+- ~NICK~ / ~USER~ → sends the ~RPL_WELCOME~ (001) preamble.
+- ~PRIVMSG NickServ IDENTIFY ...~ → responds with NickServ's
+  "You are now identified" acknowledgement.
+- ~JOIN #channel~ → echoes the ~:nick!nick@host JOIN #channel~ confirmation
+  back to the client.
+
+Each test uses ~fis-wait-for~ to block until a specific line appears in
+the server's received-line log, with a timeout to prevent hangs.
+
+A key detail: ~cl-irc~ serialises the channel as a trailing IRC argument,
+sending ~JOIN :#channel~ (with a leading colon) on the wire.  Both the
+fake server's JOIN handler and the ~fis-wait-for~ assertions use the
+colon-prefixed form.
+
+** Adding new tests
+
+- *Unit tests*: add a file to ~test/unit/~, define a package with
+  ~uiop:define-package~, import only the symbols under test, and list the
+  file in the ~:components~ of ~harlie/test/unit~ in ~harlie.asd~.  Add the
+  package name to the ~parachute:test~ call in ~harlie/test/all~.
+
+- *DB integration tests*: add a file to ~test/db/~, use
+  ~(:use #:harlie/test/db/fixture)~ to get ~with-test-db~ and ~*test-db*~,
+  wrap each test body in ~(with-test-db (unwind-protect ... (cleanup)))~.
+  List the file in ~harlie/test/db~ in ~harlie.asd~ and add the package to
+  ~harlie/test/all~.

--- a/README.org
+++ b/README.org
@@ -1,0 +1,158 @@
+#+TITLE: Harlie
+#+AUTHOR: Brian O'Reilly
+#+OPTIONS: toc:t num:nil
+
+/With respect to David Gerrold's/ When HARLIE Was One.
+
+Harlie is a multi-channel IRC bot written in Common Lisp.  It maintains
+persistent user state in PostgreSQL, shortens and annotates URLs, learns from
+conversation using a Markov chainer, and serves a small web interface per
+channel showing the URL archive and bot source.
+
+* Features
+
+- Connects to multiple IRC servers and channels simultaneously, each with its
+  own nick and web port
+- NickServ authentication and registration via an event-driven state machine
+- URL shortener with title fetching, UTM-parameter stripping, and a per-channel
+  web archive
+- Markov-chain text generation (~!babble~, ~!haiku~)
+- METAR weather lookups (~!metar~)
+- Per-user and per-channel persistent state in PostgreSQL
+- Built-in web server (Hunchentoot) per context
+- Slynk REPL server for live inspection (~slynky~)
+- Cron-style scheduled tasks
+
+* Requirements
+
+| Requirement   | Notes                                         |
+|---------------+-----------------------------------------------|
+| SBCL          | Tested on current releases                    |
+| Quicklisp     | For library loading                           |
+| PostgreSQL    | 14+ recommended; bot uses Unix socket auth    |
+| cl-irc        | Available via Quicklisp                          |
+
+All other Lisp dependencies are fetched by Quicklisp.
+
+* Quickstart
+
+** 1. Create the database
+
+#+begin_src sh
+createdb botdb
+sed 's/<bot_runner_uid>/YOUR_UNIX_USER/g' \
+    database/bot-schema.sql.template > database/bot-schema.sql
+psql botdb -f database/bot-schema.sql
+#+end_src
+
+** 2. Configure the bot
+
+Copy ~config-template.lisp~ to ~config.lisp~ and edit it:
+
+#+begin_src lisp
+(defparameter *bot-config*
+  (make-config
+   :db-credentials  (list "botdb" (uiop:getenv "USER") nil :unix)
+   :web-server-name "localhost"
+   :connections
+   (list
+    (make-connection-spec
+     :server  "irc.libera.chat" :ssl t
+     :nick    "MyBot"
+     :channel "#mychannel"
+     :web-port 9000))))
+#+end_src
+
+NickServ credentials should come from the environment, never from literals:
+
+#+begin_src lisp
+(make-connection-spec
+ ...
+ :nickserv-password (uiop:getenv "HARLIE_NICKSERV_PASSWORD")
+ :nickserv-email    (uiop:getenv "HARLIE_NICKSERV_EMAIL"))
+#+end_src
+
+#+begin_src sh
+export HARLIE_NICKSERV_PASSWORD="your-nickserv-password"
+export HARLIE_NICKSERV_EMAIL="your@email.com"
+#+end_src
+
+** 3. Load and start the bot
+
+#+begin_src lisp
+(ql:quickload :harlie)
+(in-package :harlie)
+(run-bot)
+#+end_src
+
+To also open a Slynk REPL for live inspection:
+
+#+begin_src lisp
+(slynky :port 4007)
+#+end_src
+
+** 4. Stop the bot
+
+#+begin_src lisp
+(kill-bot)
+#+end_src
+
+* Running the Tests
+
+A test database is required.  Create it once:
+
+#+begin_src sh
+createdb harlie-test
+pg_dump botdb --schema-only | psql harlie-test
+#+end_src
+
+Then from a Lisp image:
+
+#+begin_src lisp
+(asdf:test-system :harlie)
+#+end_src
+
+This runs the complete test suite: NickServ flow integration tests, pure-function
+unit tests, and database integration tests.  All tests target ~harlie-test~; the
+production ~botdb~ database is never touched.
+
+See the [[file:Manual.org][Operator's Manual]], §Testing, for a full description of the test suite
+architecture.
+
+* Configuration Reference
+
+~make-config~ accepts:
+
+| Key               | Type   | Purpose                                    |
+|-------------------+--------+--------------------------------------------|
+| ~:db-credentials~ | list   | Postmodern connection spec (db user pw host) |
+| ~:web-server-name~ | string | Hostname for web server ~Location:~ headers |
+| ~:connections~    | list   | One ~make-connection-spec~ per channel     |
+
+~make-connection-spec~ accepts:
+
+| Key                  | Required | Default | Purpose                       |
+|----------------------+----------+---------+-------------------------------|
+| ~:server~            | yes      | —       | IRC server hostname           |
+| ~:nick~              | yes      | —       | Bot nick                      |
+| ~:channel~           | yes      | —       | Channel to join               |
+| ~:ssl~               | no       | ~nil~   | Use TLS                       |
+| ~:web-port~          | no       | ~nil~   | Hunchentoot port for this context |
+| ~:channel-key~       | no       | ~nil~   | Channel password              |
+| ~:nickserv-password~ | no       | ~nil~   | NickServ IDENTIFY password    |
+| ~:nickserv-email~    | no       | ~nil~   | NickServ REGISTER email       |
+
+* IRC Commands
+
+| Command        | Effect                                          |
+|----------------+-------------------------------------------------|
+| ~!help~        | Print help URL and available commands           |
+| ~!babble~      | Generate text via Markov chain                  |
+| ~!haiku~       | Generate a haiku                                |
+| ~!metar ICAO~  | Fetch weather for airport ICAO code             |
+| ~!status~      | Short status report                             |
+| ~!status full~ | Full status including chainer phrase count      |
+
+* License
+
+See [[file:LICENSE][LICENSE]].

--- a/README.org
+++ b/README.org
@@ -25,12 +25,12 @@ channel showing the URL archive and bot source.
 
 * Requirements
 
-| Requirement   | Notes                                         |
-|---------------+-----------------------------------------------|
-| SBCL          | Tested on current releases                    |
-| Quicklisp     | For library loading                           |
-| PostgreSQL    | 14+ recommended; bot uses Unix socket auth    |
-| cl-irc        | Available via Quicklisp                          |
+| Requirement | Notes                                      |
+|-------------+--------------------------------------------|
+| SBCL        | Tested on current releases                 |
+| Quicklisp   | For library loading                        |
+| PostgreSQL  | 14+ recommended; bot uses Unix socket auth |
+| cl-irc      | Available via Quicklisp                    |
 
 All other Lisp dependencies are fetched by Quicklisp.
 
@@ -123,35 +123,35 @@ architecture.
 
 ~make-config~ accepts:
 
-| Key               | Type   | Purpose                                    |
-|-------------------+--------+--------------------------------------------|
-| ~:db-credentials~ | list   | Postmodern connection spec (db user pw host) |
-| ~:web-server-name~ | string | Hostname for web server ~Location:~ headers |
-| ~:connections~    | list   | One ~make-connection-spec~ per channel     |
+| Key              | Type   | Purpose                                      |
+|------------------+--------+----------------------------------------------|
+| ~:db-credentials~  | list   | Postmodern connection spec (db user pw host) |
+| ~:web-server-name~ | string | Hostname for web server ~Location:~ headers    |
+| ~:connections~     | list   | One ~make-connection-spec~ per channel         |
 
 ~make-connection-spec~ accepts:
 
-| Key                  | Required | Default | Purpose                       |
-|----------------------+----------+---------+-------------------------------|
-| ~:server~            | yes      | —       | IRC server hostname           |
-| ~:nick~              | yes      | —       | Bot nick                      |
-| ~:channel~           | yes      | —       | Channel to join               |
-| ~:ssl~               | no       | ~nil~   | Use TLS                       |
-| ~:web-port~          | no       | ~nil~   | Hunchentoot port for this context |
-| ~:channel-key~       | no       | ~nil~   | Channel password              |
-| ~:nickserv-password~ | no       | ~nil~   | NickServ IDENTIFY password    |
-| ~:nickserv-email~    | no       | ~nil~   | NickServ REGISTER email       |
+| Key                | Required | Default | Purpose                           |
+|--------------------+----------+---------+-----------------------------------|
+| ~:server~            | yes      | —       | IRC server hostname               |
+| ~:nick~              | yes      | —       | Bot nick                          |
+| ~:channel~           | yes      | —       | Channel to join                   |
+| ~:ssl~               | no       | ~nil~     | Use TLS                           |
+| ~:web-port~          | no       | ~nil~     | Hunchentoot port for this context |
+| ~:channel-key~       | no       | ~nil~     | Channel password                  |
+| ~:nickserv-password~ | no       | ~nil~     | NickServ IDENTIFY password        |
+| ~:nickserv-email~    | no       | ~nil~     | NickServ REGISTER email           |
 
 * IRC Commands
 
-| Command        | Effect                                          |
-|----------------+-------------------------------------------------|
-| ~!help~        | Print help URL and available commands           |
-| ~!babble~      | Generate text via Markov chain                  |
-| ~!haiku~       | Generate a haiku                                |
-| ~!metar ICAO~  | Fetch weather for airport ICAO code             |
-| ~!status~      | Short status report                             |
-| ~!status full~ | Full status including chainer phrase count      |
+| Command      | Effect                                     |
+|--------------+--------------------------------------------|
+| ~!help~        | Print help URL and available commands      |
+| ~!babble~      | Generate text via Markov chain             |
+| ~!haiku~       | Generate a haiku                           |
+| ~!metar ICAO~  | Fetch weather for airport ICAO code        |
+| ~!status~      | Short status report                        |
+| ~!status full~ | Full status including chainer phrase count |
 
 * License
 

--- a/harlie.asd
+++ b/harlie.asd
@@ -79,7 +79,35 @@
   :depends-on (#:harlie #:harlie/test/fake-irc-server #:parachute)
   :components ((:file "test/nickserv-flow")))
 
+(asdf:defsystem #:harlie/test/unit
+  :depends-on (#:harlie #:parachute)
+  :serial t
+  :components ((:module "test/unit"
+                :serial t
+                :components ((:file "urls")
+                             (:file "triggers")
+                             (:file "config")))))
+
+(asdf:defsystem #:harlie/test/db
+  :depends-on (#:harlie #:parachute #:postmodern)
+  :serial t
+  :components ((:module "test/db"
+                :serial t
+                :components ((:file "package")
+                             (:file "contexts")
+                             (:file "users")))))
+
 (asdf:defsystem #:harlie/test/all
-  :depends-on (#:harlie/test/fake-irc-server #:harlie/test/nickserv-flow #:parachute)
+  :depends-on (#:harlie/test/fake-irc-server
+               #:harlie/test/nickserv-flow
+               #:harlie/test/unit
+               #:harlie/test/db
+               #:parachute)
   :perform (asdf:test-op (op c)
-             (uiop:symbol-call :parachute :test :harlie/test/nickserv-flow)))
+             (uiop:symbol-call :parachute :test
+                               '(:harlie/test/nickserv-flow
+                                 :harlie/test/unit/urls
+                                 :harlie/test/unit/triggers
+                                 :harlie/test/unit/config
+                                 :harlie/test/db/contexts
+                                 :harlie/test/db/users))))

--- a/test/db/contexts.lisp
+++ b/test/db/contexts.lisp
@@ -1,0 +1,127 @@
+;;;; test/db/contexts.lisp
+;;;;
+;;;; Integration tests for make-context-entry and load-contexts.
+;;;; Runs against harlie-test (never botdb).
+
+(uiop:define-package #:harlie/test/db/contexts
+  (:use #:cl #:harlie/test/db/fixture)
+  (:import-from #:harlie
+                #:make-context-entry
+                #:load-contexts
+                #:make-config
+                #:make-connection-spec
+                #:*bot-config*)
+  (:local-nicknames (#:tt #:parachute)
+                    (#:pomo #:postmodern)))
+
+(in-package #:harlie/test/db/contexts)
+
+;;;; ---- helpers ----------------------------------------------------------
+
+(defun test-row-count (nick server channel)
+  "Return the number of contexts rows matching the given triple."
+  (pomo:query (:select (:count :*)
+               :from 'contexts
+               :where (:and (:= 'context-name nick)
+                            (:= 'irc-server server)
+                            (:= 'irc-channel channel)))
+              :single))
+
+(defun delete-test-rows (nick)
+  "Remove all contexts rows whose context_name starts with NICK."
+  (pomo:execute (:delete-from 'contexts
+                 :where (:like 'context-name nick))))
+
+;;;; ---- test suite -------------------------------------------------------
+
+(tt:define-test "harlie.db.contexts")
+
+(tt:define-test "make-context-entry/inserts-row"
+  :parent "harlie.db.contexts"
+  :description "A fresh insert creates exactly one row."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot" "irc.test.invalid" "#test-chan"
+                               "web.test.invalid" 9000 "/")
+           (tt:is = 1 (test-row-count "test-bot" "irc.test.invalid" "#test-chan")))
+      (delete-test-rows "test-bot"))))
+
+(tt:define-test "make-context-entry/idempotent"
+  :parent "harlie.db.contexts"
+  :description "Calling make-context-entry twice for the same key leaves exactly one row."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot" "irc.test.invalid" "#test-chan"
+                               "web.test.invalid" 9000 "/")
+           (make-context-entry "test-bot" "irc.test.invalid" "#test-chan"
+                               "web.test.invalid" 9000 "/")
+           (tt:is = 1 (test-row-count "test-bot" "irc.test.invalid" "#test-chan")))
+      (delete-test-rows "test-bot"))))
+
+(tt:define-test "make-context-entry/updates-on-conflict"
+  :parent "harlie.db.contexts"
+  :description "Re-inserting with a different web_port updates the existing row."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot" "irc.test.invalid" "#test-chan"
+                               "web.test.invalid" 9000 "/")
+           (make-context-entry "test-bot" "irc.test.invalid" "#test-chan"
+                               "web.test.invalid" 9001 "/new")
+           (let ((row (pomo:query (:select 'web-port 'web-uri-prefix
+                                   :from 'contexts
+                                   :where (:and (:= 'context-name "test-bot")
+                                                (:= 'irc-server "irc.test.invalid")
+                                                (:= 'irc-channel "#test-chan")))
+                                  :row)))
+             (tt:is = 9001 (first row))
+             (tt:is string= "/new" (second row))))
+      (delete-test-rows "test-bot"))))
+
+(tt:define-test "load-contexts/upserts-all-specs"
+  :parent "harlie.db.contexts"
+  :description "load-contexts inserts one row per connection-spec in *bot-config*."
+  (with-test-db
+    (unwind-protect
+         (let ((*bot-config*
+                 (make-config
+                  :db-credentials *test-db*
+                  :web-server-name "web.test.invalid"
+                  :connections (list
+                                (make-connection-spec
+                                 :server  "irc.test.invalid"
+                                 :nick    "test-bot-a"
+                                 :channel "#chan-a"
+                                 :web-port 9010)
+                                (make-connection-spec
+                                 :server  "irc.test.invalid"
+                                 :nick    "test-bot-b"
+                                 :channel "#chan-b"
+                                 :web-port 9011)))))
+           (load-contexts)
+           (tt:is = 1 (test-row-count "test-bot-a" "irc.test.invalid" "#chan-a"))
+           (tt:is = 1 (test-row-count "test-bot-b" "irc.test.invalid" "#chan-b")))
+      (delete-test-rows "test-bot-a")
+      (delete-test-rows "test-bot-b"))))
+
+(tt:define-test "load-contexts/idempotent"
+  :parent "harlie.db.contexts"
+  :description "Calling load-contexts twice still leaves exactly one row per spec."
+  (with-test-db
+    (unwind-protect
+         (let ((*bot-config*
+                 (make-config
+                  :db-credentials *test-db*
+                  :web-server-name "web.test.invalid"
+                  :connections (list
+                                (make-connection-spec
+                                 :server  "irc.test.invalid"
+                                 :nick    "test-bot-c"
+                                 :channel "#chan-c"
+                                 :web-port 9020)))))
+           (load-contexts)
+           (load-contexts)
+           (tt:is = 1 (test-row-count "test-bot-c" "irc.test.invalid" "#chan-c")))
+      (delete-test-rows "test-bot-c"))))

--- a/test/db/package.lisp
+++ b/test/db/package.lisp
@@ -21,17 +21,17 @@
   "Postmodern connection spec for the harlie-test database.")
 
 (defun ensure-dao-classes-finalized ()
-  "Force MOP finalization of all harlie DAO classes so that postmodern
-generates insert-dao/update-dao/etc. methods before any test runs them.
-Always re-finalize unconditionally: a class may have been redefined
-between test suites without regenerating the DAO methods."
+  "Finalize all harlie DAO classes once at load time so that postmodern
+generates insert-dao/update-dao/etc. methods before any test runs them."
   (dolist (class-name '(harlie::bot-channel
                         harlie::harlie-user
                         harlie::channel-user
                         harlie::user-alias))
     (let ((class (find-class class-name nil)))
-      (when class
+      (when (and class (not (closer-mop:class-finalized-p class)))
         (closer-mop:finalize-inheritance class)))))
+
+(ensure-dao-classes-finalized)
 
 (defmacro with-test-db (&body body)
   "Bind *BOT-CONFIG* to a minimal test config pointing at harlie-test,
@@ -40,6 +40,5 @@ then execute BODY inside a postmodern connection to that database."
                         :db-credentials *test-db*
                         :web-server-name "test.localhost"
                         :connections nil)))
-     (ensure-dao-classes-finalized)
      (postmodern:with-connection *test-db*
        ,@body)))

--- a/test/db/package.lisp
+++ b/test/db/package.lisp
@@ -1,0 +1,45 @@
+;;;; test/db/package.lisp
+;;;;
+;;;; Shared test-database fixture for harlie DB tests.
+;;;; All DB tests connect to "harlie-test" (never "botdb") and clean up
+;;;; their own rows so the suite is idempotent and repeatable.
+
+(uiop:define-package #:harlie/test/db/fixture
+  (:use #:cl)
+  (:import-from #:harlie
+                #:make-config
+                #:*bot-config*)
+  (:import-from #:closer-mop
+                #:class-finalized-p
+                #:finalize-inheritance)
+  (:export #:*test-db*
+           #:with-test-db))
+
+(in-package #:harlie/test/db/fixture)
+
+(defparameter *test-db* (list "harlie-test" (uiop:getenv "USER") nil :unix)
+  "Postmodern connection spec for the harlie-test database.")
+
+(defun ensure-dao-classes-finalized ()
+  "Force MOP finalization of all harlie DAO classes so that postmodern
+generates insert-dao/update-dao/etc. methods before any test runs them.
+Always re-finalize unconditionally: a class may have been redefined
+between test suites without regenerating the DAO methods."
+  (dolist (class-name '(harlie::bot-channel
+                        harlie::harlie-user
+                        harlie::channel-user
+                        harlie::user-alias))
+    (let ((class (find-class class-name nil)))
+      (when class
+        (closer-mop:finalize-inheritance class)))))
+
+(defmacro with-test-db (&body body)
+  "Bind *BOT-CONFIG* to a minimal test config pointing at harlie-test,
+then execute BODY inside a postmodern connection to that database."
+  `(let ((*bot-config* (make-config
+                        :db-credentials *test-db*
+                        :web-server-name "test.localhost"
+                        :connections nil)))
+     (ensure-dao-classes-finalized)
+     (postmodern:with-connection *test-db*
+       ,@body)))

--- a/test/db/users.lisp
+++ b/test/db/users.lisp
@@ -1,0 +1,119 @@
+;;;; test/db/users.lisp
+;;;;
+;;;; Integration tests for the harlie-user, bot-channel, and channel-user DAOs,
+;;;; and the higher-level helpers that wrap them.
+
+(uiop:define-package #:harlie/test/db/users
+  (:use #:cl #:harlie/test/db/fixture)
+  (:import-from #:harlie
+                #:harlie-user
+                #:harlie-user-id
+                #:harlie-user-name
+                #:current-handle
+                #:authenticated?
+                #:bot-channel
+                #:bot-channel-id
+                #:channel-name
+                #:channel-user
+                #:channel-id
+                #:user-id
+                #:ignored
+                #:make-bot-channel
+                #:get-bot-channel-for-name
+                #:get-user-for-handle
+                #:get-channel-user-mapping)
+  (:local-nicknames (#:tt #:parachute)
+                    (#:pomo #:postmodern)))
+
+(in-package #:harlie/test/db/users)
+
+;;;; ---- cleanup helpers --------------------------------------------------
+
+(defun delete-test-user (handle)
+  (pomo:execute (:delete-from 'harlie-user
+                 :where (:= 'current-handle handle))))
+
+(defun delete-test-channel (name)
+  (pomo:execute (:delete-from 'bot-channel
+                 :where (:= 'channel-name name))))
+
+;;;; ---- test suite -------------------------------------------------------
+
+(tt:define-test "harlie.db.users")
+
+;;; ---- bot-channel -------------------------------------------------------
+
+(tt:define-test "make-bot-channel/creates-row"
+  :parent "harlie.db.users"
+  :description "make-bot-channel returns a bot-channel DAO and persists it."
+  (with-test-db
+    (unwind-protect
+         (let ((bc (make-bot-channel "#test-channel-1" "irc.test.invalid")))
+           (tt:true (typep bc 'bot-channel))
+           (tt:is string= "#test-channel-1" (channel-name bc))
+           (tt:true (integerp (bot-channel-id bc))))
+      (delete-test-channel "#test-channel-1"))))
+
+(tt:define-test "make-bot-channel/idempotent"
+  :parent "harlie.db.users"
+  :description "Calling make-bot-channel twice for the same name returns the same row."
+  (with-test-db
+    (unwind-protect
+         (let* ((bc1 (make-bot-channel "#test-channel-2" "irc.test.invalid"))
+                (bc2 (make-bot-channel "#test-channel-2" "irc.test.invalid")))
+           (tt:is = (bot-channel-id bc1) (bot-channel-id bc2)))
+      (delete-test-channel "#test-channel-2"))))
+
+;;; ---- harlie-user -------------------------------------------------------
+
+(tt:define-test "get-user-for-handle/creates-user"
+  :parent "harlie.db.users"
+  :description "get-user-for-handle returns a harlie-user DAO, creating it if absent."
+  (with-test-db
+    (unwind-protect
+         (let ((u (get-user-for-handle "test-handle-1")))
+           (tt:true (typep u 'harlie-user))
+           (tt:is string= "test-handle-1" (current-handle u))
+           (tt:true (integerp (harlie-user-id u))))
+      (delete-test-user "test-handle-1"))))
+
+(tt:define-test "get-user-for-handle/idempotent"
+  :parent "harlie.db.users"
+  :description "Calling get-user-for-handle twice returns the same row."
+  (with-test-db
+    (unwind-protect
+         (let* ((u1 (get-user-for-handle "test-handle-2"))
+                (u2 (get-user-for-handle "test-handle-2")))
+           (tt:is = (harlie-user-id u1) (harlie-user-id u2)))
+      (delete-test-user "test-handle-2"))))
+
+;;; ---- channel-user ------------------------------------------------------
+
+(tt:define-test "get-channel-user-mapping/creates-mapping"
+  :parent "harlie.db.users"
+  :description "get-channel-user-mapping returns a channel-user DAO linking the two."
+  (with-test-db
+    (unwind-protect
+         (let* ((bc  (make-bot-channel "#test-channel-3" "irc.test.invalid"))
+                (u   (get-user-for-handle "test-handle-3"))
+                (c/u (get-channel-user-mapping bc u)))
+           (tt:true (typep c/u 'channel-user))
+           (tt:is = (bot-channel-id bc) (channel-id c/u))
+           (tt:is = (harlie-user-id u)  (user-id c/u))
+           (tt:false (ignored c/u)))
+      (delete-test-user "test-handle-3")
+      (delete-test-channel "#test-channel-3"))))
+
+(tt:define-test "get-channel-user-mapping/idempotent"
+  :parent "harlie.db.users"
+  :description "Calling get-channel-user-mapping twice returns the same row."
+  (with-test-db
+    (unwind-protect
+         (let* ((bc   (make-bot-channel "#test-channel-4" "irc.test.invalid"))
+                (u    (get-user-for-handle "test-handle-4"))
+                (c/u1 (get-channel-user-mapping bc u))
+                (c/u2 (get-channel-user-mapping bc u)))
+           (tt:is = (channel-id c/u1) (channel-id c/u2))
+           (tt:is = (user-id c/u1)    (user-id c/u2)))
+      (delete-test-user "test-handle-4")
+      (delete-test-channel "#test-channel-4"))))

--- a/test/unit/triggers.lisp
+++ b/test/unit/triggers.lisp
@@ -1,0 +1,51 @@
+;;;; test/unit/triggers.lisp
+;;;;
+;;;; Unit tests for make-name-detector and triggered.
+
+(uiop:define-package #:harlie/test/unit/triggers
+  (:use #:cl)
+  (:import-from #:harlie
+                #:make-name-detector)
+  (:local-nicknames (#:tt #:parachute)))
+
+(in-package #:harlie/test/unit/triggers)
+
+(tt:define-test "harlie.unit.triggers")
+
+;;;; ---- make-name-detector -----------------------------------------------
+
+(tt:define-test "make-name-detector"
+  :parent "harlie.unit.triggers"
+
+  (let ((detect (make-name-detector "harlie")))
+
+    ;; exact match
+    (tt:true (funcall detect "harlie"))
+
+    ;; case-insensitive
+    (tt:true (funcall detect "HARLIE"))
+    (tt:true (funcall detect "HaRLiE"))
+
+    ;; trailing punctuation allowed
+    (tt:true (funcall detect "harlie,"))
+    (tt:true (funcall detect "harlie:"))
+    (tt:true (funcall detect "harlie!"))
+
+    ;; leading punctuation allowed
+    (tt:true (funcall detect ",harlie"))
+    (tt:true (funcall detect "@harlie"))
+
+    ;; both sides
+    (tt:true (funcall detect ",harlie,"))
+    (tt:true (funcall detect "!harlie!"))
+
+    ;; name embedded inside a longer word — must NOT match
+    (tt:false (funcall detect "notharlie"))
+    (tt:false (funcall detect "harlienot"))
+    (tt:false (funcall detect "xharlieyz"))
+
+    ;; completely different word
+    (tt:false (funcall detect "bot"))
+
+    ;; empty token
+    (tt:false (funcall detect ""))))

--- a/test/unit/urls.lisp
+++ b/test/unit/urls.lisp
@@ -1,0 +1,84 @@
+;;;; test/unit/urls.lisp
+;;;;
+;;;; Unit tests for URL extraction and UTM-parameter stripping.
+;;;; No network, no database, no side effects.
+
+(uiop:define-package #:harlie/test/unit/urls
+  (:use #:cl)
+  (:import-from #:harlie
+                #:extract-urls
+                #:de-utm-url)
+  (:local-nicknames (#:tt #:parachute)))
+
+(in-package #:harlie/test/unit/urls)
+
+(tt:define-test "harlie.unit.urls")
+
+;;;; ---- extract-urls -----------------------------------------------------
+
+(tt:define-test "extract-urls"
+  :parent "harlie.unit.urls"
+
+  ;; basic http
+  (tt:is equal '("http://example.com")
+         (extract-urls "see http://example.com for details"))
+
+  ;; https
+  (tt:is equal '("https://example.com/path?q=1")
+         (extract-urls "check https://example.com/path?q=1 now"))
+
+  ;; www-style (no scheme)
+  (tt:is equal '("www.example.com")
+         (extract-urls "visit www.example.com please"))
+
+  ;; multiple URLs in one string
+  (tt:is = 2
+         (length (extract-urls "http://a.com and https://b.org/page")))
+
+  ;; URL at end of sentence (trailing punctuation not part of the URL)
+  (tt:true (extract-urls "go to http://example.com."))
+
+  ;; no URLs
+  (tt:is equal '()
+         (extract-urls "nothing to see here"))
+
+  ;; empty string
+  (tt:is equal '()
+         (extract-urls "")))
+
+;;;; ---- de-utm-url --------------------------------------------------------
+
+(tt:define-test "de-utm-url"
+  :parent "harlie.unit.urls"
+
+  ;; strips utm_source as query-string start
+  (tt:is string= "https://example.com/page"
+         (de-utm-url "https://example.com/page?utm_source=twitter"))
+
+  ;; strips utm_medium after another parameter
+  (tt:is string= "https://example.com/page?foo=bar"
+         (de-utm-url "https://example.com/page?foo=bar&utm_medium=social"))
+
+  ;; strips mbid tracking parameter
+  (tt:is string= "https://example.com/page"
+         (de-utm-url "https://example.com/page?mbid=social_twitter"))
+
+  ;; case-insensitive: UTM_ (uppercase)
+  (tt:is string= "https://example.com/page"
+         (de-utm-url "https://example.com/page?UTM_source=google"))
+
+  ;; case-insensitive: MbId (mixed)
+  (tt:is string= "https://example.com/"
+         (de-utm-url "https://example.com/?MbId=123"))
+
+  ;; no tracking params — returned unchanged
+  (tt:is string= "https://example.com/page?foo=bar"
+         (de-utm-url "https://example.com/page?foo=bar"))
+
+  ;; plain URL with no query string — unchanged
+  (tt:is string= "https://example.com/page"
+         (de-utm-url "https://example.com/page"))
+
+  ;; empty string — unchanged
+  (tt:is string= ""
+         (de-utm-url "")))

--- a/users.lisp
+++ b/users.lisp
@@ -26,17 +26,14 @@
           (if bco
               (values bco)
               (let ((bco (make-dao 'bot-channel
-                                   :fetch-defaults t
                                    :channel-name channel-name
                                    :server server-name)))
-                ;; (save-dao bco)
                 (values bco))))
       (database-error (e)
         (log:debug "DB ERROR: ~A" e)
         ;; we need to save the dao instance when it's created, or we
         ;; don't get the id created in the database. Like so:
         (let ((bco (make-dao 'bot-channel
-                             :fetch-defaults t
                              :channel-name channel-name
                              :server server-name)))
           (save-dao bco)


### PR DESCRIPTION
## Summary

- Adds a full test suite wired to `(asdf:test-system :harlie)`: NickServ flow integration tests, pure-function unit tests (URL extraction, name-detector, config constructors), and database integration tests (contexts, users/channels DAOs)
- Fixes fake IRC server NICK/JOIN handlers to correctly strip trailing-argument colons from the wire format
- Removes invalid `:fetch-defaults t` initarg from `make-dao` calls in `users.lisp`
- Adds `harlie/test/unit` and `harlie/test/db` ASDF subsystems to `harlie.asd`; wires all layers into `harlie/test/all`
- Fixes DAO class finalization: calls `closer-mop:finalize-inheritance` once at test package load time so postmodern generates `insert-dao`/`update-dao` methods before any test runs
- Derives test DB username from `$USER` environment variable (no hardcoded credentials)
- Adds `README.org` with feature overview, requirements, quickstart, config reference, and IRC command table
- Adds a Testing section to `Manual.org` covering test architecture, fixtures, each test layer, and a guide for adding new tests

## Test plan

- [x] `createdb harlie-test && pg_dump botdb --schema-only | psql harlie-test`
- [x] `(asdf:test-system :harlie)` — all 73 assertions pass, 0 failures
- [x] Confirm no postmodern method-redefinition warnings appear during the test run

🄯 Brian O'Reilly <fade@deepsky.com>, 2026