### PR TITLE
Fix ignore-sticky crash on private messages

### DIFF
--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -275,6 +275,11 @@ allowing for leading and trailing punctuation characters in the match."
   "Apply commands related to ignoring/not ignoring the speaker.  Return t if
    the rest of the bot should ignore this utterance; return nil otherwise."
 
+  ;; Ignore state is per-channel.  In a private message (query) channel
+  ;; is NIL, so there is nothing to look up — let the message through.
+  (unless channel
+    (return-from ignoring nil))
+
   (let ((ignore-phrase *ignore-phrase*))
     (cond ((string= ignore-phrase text)
            (log:debug "Caught BOT Ignore Phrase, ignoring cousin from across the river: ~A on channel: ~A"

--- a/users.lisp
+++ b/users.lisp
@@ -146,13 +146,15 @@ object and swap the old handle with the new one.
    between runs in CHANNEL-USER). 
    CHANNEL/USER-MAP -> per channel state for each user
    in the database."
-  `(let* ((chan (find-the-bot-state ,channel))
-          (theuserstate (gethash ,user (ignore-sticky chan)))
-          (this-user (get-user-for-handle ,user))
-          (this-channel (get-bot-channel-for-name ,channel))
-          (channel/user-map (get-channel-user-mapping this-channel this-user)))
-     (log:debug "~2&<< [WITH-CHANNEL-USER] ~%THEUSERSTATE: ~A~% THIS-USER:~A /~% USER-NAME:~A~% THIS-CHANNEL:~A~% CHANNEL/USER-MAP:~A~%>>~2%" theuserstate this-user (harlie-user-name this-user) this-channel channel/user-map)
-     ,@body))
+  `(let ((chan (find-the-bot-state ,channel)))
+     (if (null chan)
+         (log:warn "~&[WITH-CHANNEL-USER] No bot state found for channel ~A, skipping." ,channel)
+         (let* ((theuserstate (gethash ,user (ignore-sticky chan)))
+                (this-user (get-user-for-handle ,user))
+                (this-channel (get-bot-channel-for-name ,channel))
+                (channel/user-map (get-channel-user-mapping this-channel this-user)))
+           (log:debug "~2&<< [WITH-CHANNEL-USER] ~%THEUSERSTATE: ~A~% THIS-USER:~A /~% USER-NAME:~A~% THIS-CHANNEL:~A~% CHANNEL/USER-MAP:~A~%>>~2%" theuserstate this-user (harlie-user-name this-user) this-channel channel/user-map)
+           ,@body))))
 
 (defgeneric get-channel-user-mapping (channel user)
   (:documentation "given a channel object and a user object, return a mapping between them in the database."))


### PR DESCRIPTION
## Summary
- When the bot receives a PM, `channel` is NIL in `msg-hook`. If the PM text matches an ignore command, `ignoring` calls `start-ignoring` which invokes `(ignore-sticky nil)` and crashes.
- Add early return in `ignoring` when `channel` is NIL — ignore state is per-channel and meaningless in PMs.
- Add defensive NIL guard in `with-channel-user` macro for `find-the-bot-state` returning NIL.

## Test plan
- [ ] Send bot a PM containing `!ignoreme` — should not crash
- [ ] Send bot a normal PM — should not crash
- [ ] Test `!ignoreme` / `!ignoreme off` in a real channel — should still work
- [ ] Check logs for `[MSG-HOOK] Error` pattern to confirm no more NIL crashes

🅯 Brian O'Reilly <fade@deepsky.com>, 2026