### PR TITLE
Fix NickServ "not registered" regex

### DIFF
--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -634,7 +634,7 @@ access this object when we aren't in the throes of a message event."))
                       ;; Nick not registered → attempt REGISTER if we have an email,
                       ;; wait up to 5s for a response, then join regardless.
                       ((and (eq (bot-state conn) :identifying)
-                            (scan "not .* registered" text))
+                            (scan "not .*registered" text))
                        (if (nickserv-email conn)
                            (progn
                              (setf (bot-state conn) :registering)


### PR DESCRIPTION
## Summary
- The regex `"not .* registered"` requires two spaces between the words, so it never matched `"This nickname is not registered."` — only the `"not a registered"` variant.
- Drop the space before `registered` → `"not .*registered"` to handle both.
- Fixes all 3 failing NickServ flow tests.

## Test plan
- [x] `not-registered-without-email-joins-without-identification` — now passes
- [x] `not-registered-with-email-registers-then-joins` — now passes
- [x] Full suite: 119 passed, 0 failed

🅯 Brian O'Reilly <fade@deepsky.com>, 2026