### PR TITLE
Persistent memos, editquote, planetary tz, eval removal, migration scripts

### DIFF
--- a/database/add-pending-memos-table.sql
+++ b/database/add-pending-memos-table.sql
@@ -55,6 +55,22 @@ BEGIN
     END IF;
 END $$;
 
+-- ---------------------------------------------------------------------------
+-- Step 3: Grant permissions to the bot user
+--
+-- The bot connects as its own DB role, not as postgres.
+-- Adjust 'consort' below to match your bot's database user.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    EXECUTE 'GRANT ALL ON pending_memos TO consort';
+    EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE pending_memos_memo_id_seq TO consort';
+    RAISE NOTICE 'Step 3: Granted permissions on pending_memos to consort.';
+EXCEPTION WHEN undefined_object THEN
+    RAISE NOTICE 'Step 3: Role "consort" not found — adjust the GRANT to your bot user.';
+END $$;
+
 COMMIT;
 
 -- ---------------------------------------------------------------------------

--- a/database/add-pending-memos-table.sql
+++ b/database/add-pending-memos-table.sql
@@ -1,0 +1,67 @@
+-- add-pending-memos-table.sql
+--
+-- Adds the pending_memos table for persistent !tell / !memos.
+-- Memos survive bot restarts and are deleted once delivered.
+-- Safe to run on an already-migrated database — all steps are idempotent.
+--
+-- Run with:
+--   psql -U <user> <dbname> -f database/add-pending-memos-table.sql
+--
+-- Author: Glenn Thompson
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Step 1: Create pending_memos table
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'pending_memos'
+    ) THEN
+        CREATE TABLE public.pending_memos (
+            memo_id    SERIAL PRIMARY KEY,
+            sender     TEXT NOT NULL,
+            recipient  TEXT NOT NULL,
+            channel    TEXT NOT NULL,
+            message    TEXT NOT NULL,
+            created_at BIGINT NOT NULL
+        );
+        RAISE NOTICE 'Step 1: Created pending_memos table.';
+    ELSE
+        RAISE NOTICE 'Step 1: pending_memos table already exists — skipping.';
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Step 2: Create index on recipient for fast lookups (case-insensitive)
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename  = 'pending_memos'
+          AND indexname   = 'idx_pending_memos_recipient'
+    ) THEN
+        CREATE INDEX idx_pending_memos_recipient
+            ON public.pending_memos (lower(recipient));
+        RAISE NOTICE 'Step 2: Created idx_pending_memos_recipient index.';
+    ELSE
+        RAISE NOTICE 'Step 2: idx_pending_memos_recipient index already exists — skipping.';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    RAISE NOTICE '';
+    RAISE NOTICE 'Pending memos migration complete.';
+    RAISE NOTICE 'The !tell system is now persistent across bot restarts.';
+END $$;

--- a/database/add-quotes-table.sql
+++ b/database/add-quotes-table.sql
@@ -1,0 +1,64 @@
+-- add-quotes-table.sql
+--
+-- Adds the quotes table for the !quote / !addquote feature.
+-- Safe to run on an already-migrated database — all steps are idempotent.
+--
+-- Run with:
+--   psql -U <user> <dbname> -f database/add-quotes-table.sql
+--
+-- Author: Glenn Thompson
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Step 1: Create quotes table
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'quotes'
+    ) THEN
+        CREATE TABLE public.quotes (
+            quote_id SERIAL PRIMARY KEY,
+            channel  TEXT NOT NULL,
+            added_by TEXT NOT NULL,
+            quote_text TEXT NOT NULL,
+            added_at TIMESTAMP WITH TIME ZONE DEFAULT now()
+        );
+        RAISE NOTICE 'Step 1: Created quotes table.';
+    ELSE
+        RAISE NOTICE 'Step 1: quotes table already exists — skipping.';
+    END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Step 2: Create index on channel for fast per-channel lookups
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename  = 'quotes'
+          AND indexname   = 'idx_quotes_channel'
+    ) THEN
+        CREATE INDEX idx_quotes_channel ON public.quotes (channel);
+        RAISE NOTICE 'Step 2: Created idx_quotes_channel index.';
+    ELSE
+        RAISE NOTICE 'Step 2: idx_quotes_channel index already exists — skipping.';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    RAISE NOTICE '';
+    RAISE NOTICE 'Quotes migration complete.';
+    RAISE NOTICE 'The bot can now use !addquote and !quote commands.';
+END $$;

--- a/database/add-quotes-table.sql
+++ b/database/add-quotes-table.sql
@@ -52,6 +52,22 @@ BEGIN
     END IF;
 END $$;
 
+-- ---------------------------------------------------------------------------
+-- Step 3: Grant permissions to the bot user
+--
+-- The bot connects as its own DB role, not as postgres.
+-- Adjust 'consort' below to match your bot's database user.
+-- ---------------------------------------------------------------------------
+
+DO $$
+BEGIN
+    EXECUTE 'GRANT ALL ON quotes TO consort';
+    EXECUTE 'GRANT USAGE, SELECT ON SEQUENCE quotes_quote_id_seq TO consort';
+    RAISE NOTICE 'Step 3: Granted permissions on quotes to consort.';
+EXCEPTION WHEN undefined_object THEN
+    RAISE NOTICE 'Step 3: Role "consort" not found — adjust the GRANT to your bot user.';
+END $$;
+
 COMMIT;
 
 -- ---------------------------------------------------------------------------
@@ -60,5 +76,5 @@ DO $$
 BEGIN
     RAISE NOTICE '';
     RAISE NOTICE 'Quotes migration complete.';
-    RAISE NOTICE 'The bot can now use !addquote and !quote commands.';
+    RAISE NOTICE 'The bot can now use !addquote, !quote, and !editquote commands.';
 END $$;

--- a/harlie.lisp
+++ b/harlie.lisp
@@ -19,6 +19,7 @@
   (start-web-servers)
   ;; if the database isn't configured, do it.
   (initialize-startup-maybe :go? t)
+  (load-memos-from-db)
   (sleep 3)
   (start-threaded-irc-client-instances :go? t)
   (start-cron)

--- a/memo.lisp
+++ b/memo.lisp
@@ -1,8 +1,11 @@
 ;;;; memo.lisp — Leave-a-message / !tell system
 ;;
-;; In-memory memo store with optional DB persistence.
 ;; Memos are stored per-recipient (case-insensitive nick) and delivered
 ;; when the recipient next joins a channel or speaks.
+;;
+;; Persistence: memos are written through to PostgreSQL (pending_memos
+;; table) and loaded back into the in-memory cache on startup.  Run
+;; database/add-pending-memos-table.sql to create the table.
 
 (in-package #:harlie)
 
@@ -34,10 +37,68 @@ Only undelivered memos are kept; delivered ones are removed immediately.")
   "Clear the in-memory memo store. Useful for tests."
   (clrhash *pending-memos*))
 
+;;; Database persistence
+
+(defun db-store-memo (memo)
+  "Persist a pending-memo to the database. Returns the new memo_id."
+  (handler-case
+      (with-connection (db-credentials *bot-config*)
+        (query (:insert-into 'pending-memos :set
+                'sender     (pending-memo-sender memo)
+                'recipient  (pending-memo-recipient memo)
+                'channel    (pending-memo-channel memo)
+                'message    (pending-memo-message memo)
+                'created-at (pending-memo-created-at memo))
+               :none)
+        (query (:select (:raw "currval('pending_memos_memo_id_seq')")) :single))
+    (error (e)
+      (log:warn "~&[MEMO] DB store failed: ~A" e)
+      nil)))
+
+(defun db-delete-memos-for (recipient)
+  "Delete all pending memos for RECIPIENT from the database."
+  (handler-case
+      (with-connection (db-credentials *bot-config*)
+        (query (:delete-from 'pending-memos
+                :where (:= (:lower 'recipient) (:lower recipient)))
+               :none))
+    (error (e)
+      (log:warn "~&[MEMO] DB delete failed for ~A: ~A" recipient e))))
+
+(defun load-memos-from-db ()
+  "Load all pending memos from the database into the in-memory cache.
+  Called once at bot startup to restore memos that survived a restart."
+  (handler-case
+      (with-connection (db-credentials *bot-config*)
+        (let ((rows (query (:order-by
+                            (:select 'sender 'recipient 'channel
+                                     'message 'created-at
+                             :from 'pending-memos)
+                            'created-at)
+                           :rows))
+              (count 0))
+          (clrhash *pending-memos*)
+          (dolist (row rows)
+            (let ((memo (make-pending-memo
+                         :sender     (first row)
+                         :recipient  (second row)
+                         :channel    (third row)
+                         :message    (fourth row)
+                         :created-at (fifth row))))
+              (push memo (gethash (second row) *pending-memos*))
+              (incf count)))
+          (when (> count 0)
+            (log:info "~&[MEMO] Loaded ~D pending memo~:P from database." count))
+          count))
+    (error (e)
+      (log:warn "~&[MEMO] Failed to load memos from DB: ~A" e)
+      0)))
+
 ;;; Core operations
 
 (defun store-memo (sender recipient channel message)
   "Store a memo for RECIPIENT from SENDER in CHANNEL.
+Persists to the database and caches in memory.
 Returns the newly created pending-memo, or NIL if inputs are invalid."
   (when (and sender recipient channel message
              (> (length (string-trim " " message)) 0)
@@ -47,6 +108,7 @@ Returns the newly created pending-memo, or NIL if inputs are invalid."
                                     :channel channel
                                     :message (string-trim " " message))))
       (push memo (gethash recipient *pending-memos*))
+      (db-store-memo memo)
       memo)))
 
 (defun pending-memos-for (recipient)
@@ -104,9 +166,10 @@ Returns the number of memos delivered."
               (incf count))
           (error (e)
             (log:warn "~&[MEMO] Error delivering memo to ~A: ~A" recipient e)))))
-    ;; Remove delivered memos
+    ;; Remove delivered memos from memory and database
     (when (> count 0)
-      (remhash recipient *pending-memos*))
+      (remhash recipient *pending-memos*)
+      (db-delete-memos-for recipient))
     count))
 
 ;;; Query helpers (for !memos command)

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -898,22 +898,34 @@ Returns :ok, :not-found, or :not-owner."
 ;;; Sandboxed CL evaluator
 ;;; ============================================================
 
-(defparameter *eval-banned-symbols*
-  '(eval load compile open delete-file rename-file ensure-directories-exist
-    run-program run-shell-command sb-ext:run-program uiop:run-program
-    with-open-file with-open-stream make-instance
-    require asdf:load-system ql:quickload
-    sb-ext:exit sb-ext:quit
-    setf setq defvar defparameter defun defmacro defclass
-    in-package delete-package make-package)
-  "Symbols that are not allowed in !eval expressions.")
+(defparameter *eval-banned-cl-symbols*
+  '(eval load compile compile-file open close delete-file rename-file
+    ensure-directories-exist probe-file file-write-date file-author truename
+    directory wild-pathname-p translate-pathname merge-pathnames
+    with-open-file with-open-stream with-input-from-string
+    make-instance make-condition signal error cerror warn invoke-restart
+    require provide
+    setf setq defvar defparameter defun defmacro defclass defgeneric defmethod
+    in-package delete-package make-package use-package shadow export import
+    intern find-symbol)
+  "CL symbols banned from !eval even though they're in the COMMON-LISP package.")
 
 (defun safe-eval-p (form)
-  "Check if FORM is safe to evaluate (no banned symbols)."
+  "Check if FORM is safe to evaluate.
+Only symbols from COMMON-LISP (minus banned ones) and KEYWORD are allowed.
+This blocks all external packages (UIOP, SB-EXT, SB-POSIX, ASDF, etc.)."
   (cond
     ((null form) t)
     ((symbolp form)
-     (not (member form *eval-banned-symbols* :test #'eq)))
+     (let ((pkg (symbol-package form)))
+       (cond
+         ;; Keywords are always safe
+         ((eq pkg (find-package :keyword)) t)
+         ;; CL symbols are safe unless banned
+         ((eq pkg (find-package :common-lisp))
+          (not (member form *eval-banned-cl-symbols* :test #'eq)))
+         ;; Everything else (uiop, sb-ext, sb-posix, asdf, etc.) is blocked
+         (t nil))))
     ((atom form) t)
     ((consp form)
      (and (safe-eval-p (car form))

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -758,6 +758,23 @@ error."
                       :row)))
       row)))
 
+(defun db-edit-quote (channel id sender new-text)
+  "Update a quote's text, but only if SENDER matches the original added_by.
+Returns :ok, :not-found, or :not-owner."
+  (with-connection (db-credentials *bot-config*)
+    (let ((existing (query (:select 'added-by :from 'quotes
+                            :where (:and (:= 'channel channel)
+                                         (:= 'quote-id id)))
+                           :row)))
+      (cond
+        ((null existing) :not-found)
+        ((not (string-equal sender (first existing))) :not-owner)
+        (t (query (:update 'quotes :set 'quote-text new-text
+                   :where (:and (:= 'channel channel)
+                                (:= 'quote-id id)))
+                  :none)
+           :ok)))))
+
 (defun db-get-random-quote (channel)
   "Retrieve a random quote for the channel. Returns (id sender text) or nil."
   (with-connection (db-credentials *bot-config*)
@@ -805,6 +822,31 @@ error."
                           "No quotes saved yet. Use !addquote to add one.")))
               (error (e)
                 (format nil "Error retrieving quote: ~A" e)))))))
+
+(defplugin editquote (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Edit a quote you added. Usage: !editquote <number> <new text>")
+    (:priority 1.5)
+    (:run (let* ((tokens (plugin-token-text-list plug-request))
+                 (num-str (second tokens))
+                 (num (when num-str (parse-integer num-str :junk-allowed t)))
+                 (new-text (format nil "~{~A~^ ~}" (cddr tokens)))
+                 (channel (plugin-channel-name plug-request))
+                 (sender (prefix-nick (parse-prefix (message-prefix (last-message (plugin-conn plug-request)))))))
+            (cond
+              ((null num)
+               "Usage: !editquote <number> <new text>")
+              ((str:empty? new-text)
+               "Usage: !editquote <number> <new text>")
+              (t
+               (handler-case
+                   (let ((result (db-edit-quote channel num sender new-text)))
+                     (case result
+                       (:ok (format nil "Quote #~D updated." num))
+                       (:not-found (format nil "No quote #~D found." num))
+                       (:not-owner (format nil "Only the original author can edit quote #~D." num))))
+                 (error (e)
+                   (format nil "Error editing quote: ~A" e)))))))))
 
 ;;; ============================================================
 ;;; Self-reminders

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -673,6 +673,60 @@ error."
                 (or (dict-lookup word)
                     (format nil "No definition found for '~A'." word)))))))
 
+;;; Planetary time
+;;; Rotation periods in Earth seconds (sidereal day).
+;;; Epoch: J2000.0 = 2000-01-01 12:00:00 UTC = 3155760000 universal-time
+
+(defparameter *j2000-universal-time* 3155760000
+  "J2000.0 epoch as Lisp universal-time (2000-01-01 12:00:00 UTC).")
+
+(defparameter *planet-data*
+  '(("mercury"  (:day-seconds  5067360   :abbrev "MET"  :emoji "☿"
+                 :note "1 solar day = 176 Earth days (tidally locked 3:2)"))
+    ("venus"    (:day-seconds  20996928  :abbrev "VET"  :emoji "♀"
+                 :note "1 day = 243 Earth days (retrograde rotation)"))
+    ("earth"    (:day-seconds  86164     :abbrev "UTC"  :emoji "🜨"
+                 :note "1 sidereal day = 23h 56m 4s"))
+    ("mars"     (:day-seconds  88642     :abbrev "MTC"  :emoji "♂"
+                 :note "1 sol = 24h 37m 22s"))
+    ("jupiter"  (:day-seconds  35730     :abbrev "JOT"  :emoji "♃"
+                 :note "1 day = 9h 55m 30s"))
+    ("saturn"   (:day-seconds  38362     :abbrev "SAT"  :emoji "♄"
+                 :note "1 day = 10h 39m 22s"))
+    ("uranus"   (:day-seconds  62064     :abbrev "URT"  :emoji "♅"
+                 :note "1 day = 17h 14m 24s (retrograde)"))
+    ("neptune"  (:day-seconds  57996     :abbrev "NPT"  :emoji "♆"
+                 :note "1 day = 16h 6m 36s"))
+    ("pluto"    (:day-seconds  551857    :abbrev "PLT"  :emoji "♇"
+                 :note "1 day = 6.39 Earth days (retrograde)")))
+  "Solar system planets with sidereal rotation periods.")
+
+(defun get-planet-data (name)
+  "Look up planet by name (case-insensitive). Returns plist or nil."
+  (second (assoc name *planet-data* :test #'string-equal)))
+
+(defun format-planet-time (planet-name)
+  "Compute and format the current 'local time' on a planet.
+Maps elapsed Earth seconds since J2000 into planetary day cycles,
+then projects the fractional day onto a 24-hour clock."
+  (let ((pdata (get-planet-data planet-name)))
+    (when pdata
+      (let* ((day-secs (getf pdata :day-seconds))
+             (abbrev   (getf pdata :abbrev))
+             (emoji    (getf pdata :emoji))
+             (note     (getf pdata :note))
+             (elapsed  (- (get-universal-time) *j2000-universal-time*))
+             (total-days (floor elapsed day-secs))
+             (frac     (/ (mod elapsed day-secs) day-secs))
+             ;; Map fractional planetary day to 24-hour clock
+             (day-hrs  (* frac 24.0))
+             (hrs      (floor day-hrs))
+             (mins     (floor (* (- day-hrs hrs) 60)))
+             (secs     (floor (* (- (* (- day-hrs hrs) 60) mins) 60))))
+        (format nil "~A ~A: ~2,'0D:~2,'0D:~2,'0D ~A — Sol ~:D (~A)"
+                emoji (string-capitalize planet-name)
+                hrs mins secs abbrev total-days note)))))
+
 (defvar *timezones-loaded* nil)
 
 (defun ensure-timezones-loaded ()
@@ -686,23 +740,29 @@ error."
     (:docstring "Show current time in a timezone. Usage: !tz <timezone> (e.g. US/Eastern, Europe/London)")
     (:priority 3.0)
     (:run (let ((zone-name (second (plugin-token-text-list plug-request))))
-            (if (null zone-name)
-                "Usage: !tz <timezone> (e.g. US/Eastern, Europe/London, Asia/Tokyo)"
-                (handler-case
-                    (progn
-                      (ensure-timezones-loaded)
-                      (let ((tz (local-time:find-timezone-by-location-name zone-name)))
-                        (if tz
-                            (let* ((now (local-time:now))
-                                   (formatted (local-time:format-timestring
-                                               nil now
-                                               :format '((:year 4) #\- (:month 2) #\- (:day 2)
-                                                         #\Space (:hour 2) #\: (:min 2) #\: (:sec 2))
-                                               :timezone tz)))
-                              (format nil "~A: ~A" zone-name formatted))
-                            (format nil "Unknown timezone '~A'. Try e.g. US/Eastern, Europe/London, Asia/Tokyo" zone-name))))
-                  (error ()
-                    (format nil "Unknown timezone '~A'. Try e.g. US/Eastern, Europe/London, Asia/Tokyo" zone-name))))))))
+            (cond
+              ((null zone-name)
+               "Usage: !tz <timezone|planet> (e.g. US/Eastern, Europe/London, Mars, Neptune)")
+              ;; Check for planetary time first
+              ((get-planet-data zone-name)
+               (format-planet-time zone-name))
+              ;; Otherwise try Earth timezone
+              (t
+               (handler-case
+                   (progn
+                     (ensure-timezones-loaded)
+                     (let ((tz (local-time:find-timezone-by-location-name zone-name)))
+                       (if tz
+                           (let* ((now (local-time:now))
+                                  (formatted (local-time:format-timestring
+                                              nil now
+                                              :format '((:year 4) #\- (:month 2) #\- (:day 2)
+                                                        #\Space (:hour 2) #\: (:min 2) #\: (:sec 2))
+                                              :timezone tz)))
+                             (format nil "~A: ~A" zone-name formatted))
+                           (format nil "Unknown timezone '~A'. Try e.g. US/Eastern, Europe/London, Mars, Neptune" zone-name))))
+                 (error ()
+                   (format nil "Unknown timezone '~A'. Try e.g. US/Eastern, Europe/London, Mars, Neptune" zone-name)))))))))
 
 (defun github-repo-summary (repo-path)
   "Fetch a GitHub repo summary. REPO-PATH is 'owner/repo'."

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -954,68 +954,7 @@ Returns :ok, :not-found, or :not-owner."
                   :name (format nil "reminder-~A" sender))
                  (format nil "Got it, I'll remind you in ~A." (format-duration seconds)))))))))
 
-;;; ============================================================
-;;; Sandboxed CL evaluator
-;;; ============================================================
-
-(defparameter *eval-banned-cl-symbols*
-  '(eval load compile compile-file open close delete-file rename-file
-    ensure-directories-exist probe-file file-write-date file-author truename
-    directory wild-pathname-p translate-pathname merge-pathnames
-    with-open-file with-open-stream with-input-from-string
-    make-instance make-condition signal error cerror warn invoke-restart
-    require provide
-    setf setq defvar defparameter defun defmacro defclass defgeneric defmethod
-    in-package delete-package make-package use-package shadow export import
-    intern find-symbol)
-  "CL symbols banned from !eval even though they're in the COMMON-LISP package.")
-
-(defun safe-eval-p (form)
-  "Check if FORM is safe to evaluate.
-Only symbols from COMMON-LISP (minus banned ones) and KEYWORD are allowed.
-This blocks all external packages (UIOP, SB-EXT, SB-POSIX, ASDF, etc.)."
-  (cond
-    ((null form) t)
-    ((symbolp form)
-     (let ((pkg (symbol-package form)))
-       (cond
-         ;; Keywords are always safe
-         ((eq pkg (find-package :keyword)) t)
-         ;; CL symbols are safe unless banned
-         ((eq pkg (find-package :common-lisp))
-          (not (member form *eval-banned-cl-symbols* :test #'eq)))
-         ;; Everything else (uiop, sb-ext, sb-posix, asdf, etc.) is blocked
-         (t nil))))
-    ((atom form) t)
-    ((consp form)
-     (and (safe-eval-p (car form))
-          (safe-eval-p (cdr form))))
-    (t t)))
-
-;; this plugin is too dangerous to live, glenneth. -F
-;; (defplugin eval (plug-request)
-;;   (case (plugin-action plug-request)
-;;     (:docstring "Evaluate a Common Lisp expression (sandboxed). Usage: !eval <expr>")
-;;     (:priority 3.0)
-;;     (:run (let* ((tokens (plugin-token-text-list plug-request))
-;;                  (expr-str (format nil "~{~A~^ ~}" (rest tokens))))
-;;             (if (str:empty? expr-str)
-;;                 "Usage: !eval (+ 1 2)"
-;;                 (handler-case
-;;                     (trivial-timeout:with-timeout (5)
-;;                       (let ((form (let ((*read-eval* nil))
-;;                                     (read-from-string expr-str))))
-;;                         (if (safe-eval-p form)
-;;                             (let* ((result (eval form))
-;;                                    (text (format nil "~S" result)))
-;;                               (if (> (length text) 400)
-;;                                   (format nil "~A... [truncated]" (subseq text 0 400))
-;;                                   text))
-;;                             "Expression contains forbidden operations.")))
-;;                   (trivial-timeout:timeout-error ()
-;;                     "Evaluation timed out (5s limit).")
-;;                   (error (e)
-;;                     (format nil "Error: ~A" e))))))))
+;;; !eval removed — "this plugin is too dangerous to live" -Fade
 
 ;; ===[ hyperspace motivator follows. ]===
 


### PR DESCRIPTION
Summary of changes:

- **Persistent !tell memos** — memos now write through to PostgreSQL (pending_memos table) and survive bot restarts. Loaded back into memory on startup.
- **!editquote plugin** — allows original poster to edit their quotes: `!editquote <id> <new text>`
- **Planetary time in !tz** — `!tz Mars`, `!tz Neptune`, etc. show a solar system clock (sidereal day mapped to 24h clock, sol count, day length info)
- **Remove !eval plugin** — agreed, too dangerous to live. Removed sandbox code and plugin entirely.
- **Migration scripts** — `database/add-pending-memos-table.sql` and `database/add-quotes-table.sql` with idempotent DDL and GRANT statements for bot DB user.
- **GRANT statements** — both migration scripts now grant table + sequence permissions to the bot role.

Migration instructions:
```
psql -U <user> <dbname> -f database/add-quotes-table.sql
psql -U <user> <dbname> -f database/add-pending-memos-table.sql
```
Adjust the role name in the GRANT sections if your bot user differs from "consort".