### PR TITLE
Record binary filename in URL shortener title

### DIFF
--- a/harlie.asd
+++ b/harlie.asd
@@ -102,10 +102,15 @@
   :depends-on (#:harlie #:harlie/test/fake-irc-server #:parachute)
   :components ((:file "test/memo-test")))
 
+(asdf:defsystem #:harlie/test/url-shortener
+  :depends-on (#:harlie #:harlie/test/fake-irc-server #:parachute)
+  :components ((:file "test/url-shortener-test")))
+
 (asdf:defsystem #:harlie/test/all
   :depends-on (#:harlie/test/fake-irc-server
                #:harlie/test/nickserv-flow
                #:harlie/test/memo
+               #:harlie/test/url-shortener
                #:harlie/test/unit
                #:harlie/test/db
                #:parachute)
@@ -113,6 +118,7 @@
              (uiop:symbol-call :parachute :test
                                '(:harlie/test/nickserv-flow
                                  :harlie/test/memo
+                                 :harlie/test/url-shortener
                                  :harlie/test/unit/urls
                                  :harlie/test/unit/triggers
                                  :harlie/test/unit/config

--- a/test/unit/urls.lisp
+++ b/test/unit/urls.lisp
@@ -7,7 +7,8 @@
   (:use #:cl)
   (:import-from #:harlie
                 #:extract-urls
-                #:de-utm-url)
+                #:de-utm-url
+                #:get-filename-from-url)
   (:local-nicknames (#:tt #:parachute)))
 
 (in-package #:harlie/test/unit/urls)
@@ -82,3 +83,28 @@
   ;; empty string — unchanged
   (tt:is string= ""
          (de-utm-url "")))
+
+;;;; ---- get-filename-from-url -----------------------------------------------
+
+(tt:define-test "get-filename-from-url"
+  :parent "harlie.unit.urls"
+
+  ;; simple binary filename
+  (tt:is string= "archive.tar.gz"
+         (get-filename-from-url "https://example.com/files/archive.tar.gz"))
+
+  ;; filename with no directory
+  (tt:is string= "image.iso"
+         (get-filename-from-url "https://example.com/image.iso"))
+
+  ;; deep path
+  (tt:is string= "package.deb"
+         (get-filename-from-url "https://mirror.example.com/debian/pool/main/p/pkg/package.deb"))
+
+  ;; URL with query string — filename still extracted from path
+  (tt:is string= "release.zip"
+         (get-filename-from-url "https://example.com/downloads/release.zip?token=abc123"))
+
+  ;; URL ending in slash — no filename
+  (tt:is string= ""
+         (get-filename-from-url "https://example.com/path/")))

--- a/test/url-shortener-test.lisp
+++ b/test/url-shortener-test.lisp
@@ -1,0 +1,125 @@
+;;;; test/url-shortener-test.lisp
+;;;;
+;;;; Integration test for the binary URL shortening codepath.
+;;;; Uses the fake-irc-server to exercise the full msg-hook → store-binary-url
+;;;; → channel reply flow, with a mock URL store to avoid hitting the database.
+
+(uiop:define-package #:harlie/test/url-shortener
+  (:use #:cl #:harlie/test/fake-irc-server)
+  (:import-from #:harlie
+                #:make-bot-connection #:make-irc-client-instance-thunk
+                #:bot-state #:*irc-connections* #:*the-url-store*
+                #:get-filename-from-url
+                #:store-binary-url #:lookup-url
+                #:make-short-url-string)
+  (:import-from #:clatter-irc #:disconnect)
+  (:import-from #:bordeaux-threads #:make-thread #:destroy-thread)
+  (:local-nicknames (#:tt #:parachute)))
+
+(in-package #:harlie/test/url-shortener)
+
+;;;; ---- Mock URL store -------------------------------------------------------
+;;
+;; Avoids all database access.  store-binary-url returns a canned short URL
+;; and the "Binary File: <filename>" title, exactly as the real method does
+;; after a successful insert.
+
+(defclass fake-url-store () ()
+  (:documentation "A mock URL store that returns predictable values without DB access."))
+
+(defmethod store-binary-url ((store fake-url-store) context url nick)
+  "Return a fake short URL and the binary-file title with filename."
+  (values (make-short-url-string context "FAKE")
+          (format nil "Binary File: ~A" (get-filename-from-url url))))
+
+(defmethod lookup-url ((store fake-url-store) context url nick)
+  "Return a fake short URL and a canned title for non-binary URLs."
+  (values (make-short-url-string context "FAKE")
+          "Fake Page Title"))
+
+;;;; ---- Helpers --------------------------------------------------------------
+
+(defun wait-for-bot-state (conn target-state &key (timeout 5))
+  "Wait up to TIMEOUT seconds for CONN to reach TARGET-STATE."
+  (let ((deadline (+ (get-internal-real-time)
+                     (* timeout internal-time-units-per-second))))
+    (loop while (and (not (eq (bot-state conn) target-state))
+                     (< (get-internal-real-time) deadline))
+          do (sleep 0.05))
+    (eq (bot-state conn) target-state)))
+
+(defmacro with-fake-url-store (&body body)
+  "Temporarily replace *the-url-store* with a fake-url-store, restoring on exit."
+  (let ((saved (gensym "SAVED-STORE")))
+    `(let ((,saved harlie::*the-url-store*))
+       (unwind-protect
+            (progn
+              (setf harlie::*the-url-store* (make-instance 'fake-url-store))
+              ,@body)
+         (setf harlie::*the-url-store* ,saved)))))
+
+;;;; ---- Test suite -----------------------------------------------------------
+
+(tt:define-test "url-shortener-tests")
+
+(tt:define-test "binary-url-returns-filename-in-title"
+  :parent "url-shortener-tests"
+  :description "When a user pastes a binary URL, the bot replies with 'Binary File: <filename>'."
+  (with-fake-url-store
+    (with-fake-irc-server (server)
+      (let ((conn (make-bot-connection "TestBot" "127.0.0.1" :default
+                                      :port (fis-port server))))
+        (unwind-protect
+             (progn
+               (let ((bot-thread
+                       (bt:make-thread
+                        (make-irc-client-instance-thunk
+                         "TestBot" "#test" nil "127.0.0.1" conn)
+                        :name "url-test-bot")))
+                 (declare (ignorable bot-thread))
+                 ;; Wait for bot to join
+                 (tt:true (fis-wait-for server "JOIN #test"))
+                 (tt:true (wait-for-bot-state conn :joined))
+
+                 ;; Simulate a user posting a binary URL (.png is in *binary-url-suffixes*)
+                 (fis-inject server
+                             ":someone!user@example.com PRIVMSG #test :check this out https://localhost/files/screenshot.png")
+
+                 ;; The bot should reply with a PRIVMSG containing the filename
+                 (tt:true (fis-wait-for server "Binary File: screenshot.png"))))
+          ;; Cleanup
+          (handler-case (disconnect conn "test done") (error () nil))
+          (sleep 0.2)
+          (remhash (list "127.0.0.1" "TESTBOT") *irc-connections*))))))
+
+(tt:define-test "binary-url-different-suffixes"
+  :parent "url-shortener-tests"
+  :description "Various binary suffixes all produce the filename in the reply."
+  (with-fake-url-store
+    (with-fake-irc-server (server)
+      (let ((conn (make-bot-connection "TestBot" "127.0.0.1" :default
+                                      :port (fis-port server))))
+        (unwind-protect
+             (progn
+               (let ((bot-thread
+                       (bt:make-thread
+                        (make-irc-client-instance-thunk
+                         "TestBot" "#test" nil "127.0.0.1" conn)
+                        :name "url-test-bot2")))
+                 (declare (ignorable bot-thread))
+                 (tt:true (fis-wait-for server "JOIN #test"))
+                 (tt:true (wait-for-bot-state conn :joined))
+
+                 ;; Post a .jpg URL
+                 (fis-inject server
+                             ":someone!user@example.com PRIVMSG #test :look https://cdn.localhost/photos/sunset.jpg")
+                 (tt:true (fis-wait-for server "Binary File: sunset.jpg"))
+
+                 ;; Post a .mp4 URL
+                 (fis-inject server
+                             ":someone!user@example.com PRIVMSG #test :video https://media.localhost/clips/cat.mp4")
+                 (tt:true (fis-wait-for server "Binary File: cat.mp4"))))
+          ;; Cleanup
+          (handler-case (disconnect conn "test done") (error () nil))
+          (sleep 0.2)
+          (remhash (list "127.0.0.1" "TESTBOT") *irc-connections*))))))

--- a/url-store.lisp
+++ b/url-store.lisp
@@ -142,6 +142,12 @@
 	((not (query (:select '* :from 'urls :where (:= 'short-url short))))
 	 short))))
 
+(defun get-filename-from-url (url-string)
+  "Given a string encoded URL, return the filename it points to."
+  (let* ((uri (quri:uri url-string))
+         (path (quri:uri-path uri)))
+    (file-namestring path)))
+
 (defgeneric store-binary-url (store context url nick)
   (:documentation "Index a binary-suffixed URL with title 'Binary File', skipping fetch-title.
 Return the short URL and title, or existing values if already stored."))
@@ -150,9 +156,9 @@ Return the short URL and title, or existing values if already stored."))
   (let ((result (with-connection (readwrite-url-db store)
 		  (query (:order-by
 			  (:select 'short-url 'title
-				   :from 'urls
-				   :where (:or (:= 'input-url url)
-					       (:= 'redirected-url url)))
+                            :from 'urls
+                            :where (:or (:= 'input-url url)
+                                        (:= 'redirected-url url)))
 			  (:raw "tstamp desc"))))))
     (if result
 	(destructuring-bind (short title) (first result)
@@ -166,7 +172,7 @@ Return the short URL and title, or existing values if already stored."))
 				       :title "Binary File"
 				       :from-nick nick
 				       :context-id (url-write-context-id context)))
-	    (values (make-short-url-string context short) "Binary File"))))))
+	    (values (make-short-url-string context short) (format nil "~A: ~A" "Binary File" (get-filename-from-url url))))))))
 
 (defgeneric lookup-url (store context url nick)
   (:documentation "Return present or new short URL and title for specified URL."))


### PR DESCRIPTION
## Summary
- Extract the filename from binary URLs and include it in the shortener output
- Channel now sees "Binary File: somefile.tar.gz" instead of just "Binary File"
- Unit tests for `get-filename-from-url` covering various path shapes
- Integration tests exercise the full msg-hook → store-binary-url → channel reply codepath using a mock URL store and the fake IRC server

## Test plan
- [x] Unit tests: `get-filename-from-url` with .tar.gz, .iso, .deb, .zip, trailing slash
- [x] Integration: bot replies with "Binary File: screenshot.png" for .png URL
- [x] Integration: bot replies with "Binary File: sunset.jpg" for .jpg URL
- [x] Integration: bot replies with "Binary File: cat.mp4" for .mp4 URL
- [x] Full suite: 131 passed, 0 failed

🅯 Brian O'Reilly <fade@deepsky.com>, 2026