### PR TITLE
Fix bot-context lookup fall-through for PMs and case-mismatched channels

### DIFF
--- a/context.lisp
+++ b/context.lisp
@@ -16,36 +16,48 @@
         (let* ((context-query-head '(:select 'context-name 'irc-server 'irc-channel
                                      'web-server 'web-port 'web-uri-prefix
                                      :from 'contexts))
-               (context-query
-                (cond
-                  ;; Nick + channel: exact per-channel lookup.
-                  ((and (bot-nick context)
-                        (bot-irc-channel context)
-                        (stringp (bot-irc-channel context)))
-                   (append context-query-head
-                           `(:where (:and
-                                     (:= (:raw "lower(context_name)")
-                                         ,(string-downcase (bot-nick context)))
-                                     (:= 'irc-channel
-                                         ,(bot-irc-channel context))))))
-                  ;; Nick only: falls back to first matching row.
-                  ((bot-nick context)
-                   (append context-query-head
-                           `(:where (:= (:raw "lower(context_name)")
-                                        ,(string-downcase (bot-nick context))))))
-                  ;; Web port lookup (for URL context).
-                  ((bot-web-port context)
-                   (append context-query-head
-                           `(:where (:= 'web-port ,(bot-web-port context)))))
-                  (t nil))))
-          (let ((conlist (first (query (sql-compile context-query)))))
-            (when conlist
-              (setf (bot-nick context) (string-downcase (first conlist)))
-              (setf (bot-irc-server context) (second conlist))
-              (setf (bot-irc-channel context) (third conlist))
-              (setf (bot-web-server context) (fourth conlist))
-              (setf (bot-web-port context) (fifth conlist))
-              (setf (bot-uri-prefix context) (sixth conlist))))))
+               ;; Try each query in order and stop at the first non-empty result.
+               ;; The previous cond-based version only ran the single branch
+               ;; selected by which slots were populated, with no fall-through.
+               ;; PMs (where channel-name is the bot's own nick, not a real
+               ;; channel), case-mismatched channel names, and channels missing
+               ;; from the contexts table all left web-server/web-port nil.
+               (nick+channel-query
+                (when (and (bot-nick context)
+                           (bot-irc-channel context)
+                           (stringp (bot-irc-channel context)))
+                  (append context-query-head
+                          `(:where (:and
+                                    (:= (:raw "lower(context_name)")
+                                        ,(string-downcase (bot-nick context)))
+                                    ;; Case-insensitive on irc_channel too:
+                                    ;; IRC channel names are case-insensitive
+                                    ;; on the wire but this column is compared
+                                    ;; as text.
+                                    (:= (:raw "lower(irc_channel)")
+                                        ,(string-downcase (bot-irc-channel context))))))))
+               (nick-only-query
+                (when (bot-nick context)
+                  (append context-query-head
+                          `(:where (:= (:raw "lower(context_name)")
+                                       ,(string-downcase (bot-nick context)))))))
+               (web-port-query
+                (when (bot-web-port context)
+                  (append context-query-head
+                          `(:where (:= 'web-port ,(bot-web-port context))))))
+               (conlist (or (and nick+channel-query
+                                 (first (query (sql-compile nick+channel-query))))
+                            (and nick-only-query
+                                 (first (query (sql-compile nick-only-query))))
+                            (and web-port-query
+                                 (first (query (sql-compile web-port-query)))))))
+          (when conlist
+            (setf (bot-nick context) (string-downcase (first conlist)))
+            (setf (bot-irc-server context) (second conlist))
+            (setf (bot-irc-channel context) (third conlist))
+            (setf (bot-web-server context) (fourth conlist))
+            (setf (bot-web-port context) (fifth conlist))
+            (setf (bot-uri-prefix context) (sixth conlist)))))
     (error (e)
       (log:warn "~&[CONTEXT] DB lookup failed, using partial context: ~A" e))))
 

--- a/test/db/contexts.lisp
+++ b/test/db/contexts.lisp
@@ -10,7 +10,12 @@
                 #:load-contexts
                 #:make-config
                 #:make-connection-spec
-                #:*bot-config*)
+                #:*bot-config*
+                #:bot-context
+                #:bot-nick
+                #:bot-irc-channel
+                #:bot-web-server
+                #:bot-web-port)
   (:local-nicknames (#:tt #:parachute)
                     (#:pomo #:postmodern)))
 
@@ -125,3 +130,75 @@
            (load-contexts)
            (tt:is = 1 (test-row-count "test-bot-c" "irc.test.invalid" "#chan-c")))
       (delete-test-rows "test-bot-c"))))
+
+;;;; ---- bot-context initialize-instance lookup ----------------------------
+;;
+;; These cover the fall-through added in context.lisp:
+;;   1. exact nick+channel lookup (case-insensitive on both columns)
+;;   2. nick-only fallback when nick+channel finds nothing
+;; Before the fix, only the first branch ran, leaving web-server/web-port
+;; nil for PMs and case-mismatched channel names.
+
+(tt:define-test "bot-context/exact-nick+channel-lookup"
+  :parent "harlie.db.contexts"
+  :description "A fresh bot-context with matching nick+channel populates web-server/web-port."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot-ctx" "irc.test.invalid" "#chan-ctx"
+                               "web.test.invalid" 9030 "/")
+           (let ((ctx (make-instance 'bot-context
+                                     :bot-nick "test-bot-ctx"
+                                     :bot-irc-channel "#chan-ctx")))
+             (tt:is string= "web.test.invalid" (bot-web-server ctx))
+             (tt:is = 9030 (bot-web-port ctx))))
+      (delete-test-rows "test-bot-ctx"))))
+
+(tt:define-test "bot-context/channel-case-insensitive"
+  :parent "harlie.db.contexts"
+  :description "irc_channel comparison is case-insensitive: '#ChAn-Ctx' finds row for '#chan-ctx'."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot-ctx" "irc.test.invalid" "#chan-ctx"
+                               "web.test.invalid" 9030 "/")
+           ;; Mismatched case in the channel name — used to fail.
+           (let ((ctx (make-instance 'bot-context
+                                     :bot-nick "test-bot-ctx"
+                                     :bot-irc-channel "#ChAn-Ctx")))
+             (tt:is string= "web.test.invalid" (bot-web-server ctx))
+             (tt:is = 9030 (bot-web-port ctx))))
+      (delete-test-rows "test-bot-ctx"))))
+
+(tt:define-test "bot-context/pm-falls-through-to-nick-only"
+  :parent "harlie.db.contexts"
+  :description "When channel-name is the bot's own nick (PM), fall through to nick-only lookup."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot-ctx" "irc.test.invalid" "#chan-ctx"
+                               "web.test.invalid" 9030 "/")
+           ;; Simulate a PM: channel-name equals the bot's own nick, which
+           ;; matches no contexts row directly.  The fall-through should
+           ;; populate web-server/web-port from the nick-only lookup.
+           (let ((ctx (make-instance 'bot-context
+                                     :bot-nick "test-bot-ctx"
+                                     :bot-irc-channel "test-bot-ctx")))
+             (tt:is string= "web.test.invalid" (bot-web-server ctx))
+             (tt:is = 9030 (bot-web-port ctx))))
+      (delete-test-rows "test-bot-ctx"))))
+
+(tt:define-test "bot-context/unknown-channel-falls-through"
+  :parent "harlie.db.contexts"
+  :description "An unknown channel name falls through to the nick-only lookup."
+  (with-test-db
+    (unwind-protect
+         (progn
+           (make-context-entry "test-bot-ctx" "irc.test.invalid" "#chan-ctx"
+                               "web.test.invalid" 9030 "/")
+           (let ((ctx (make-instance 'bot-context
+                                     :bot-nick "test-bot-ctx"
+                                     :bot-irc-channel "#never-joined")))
+             (tt:is string= "web.test.invalid" (bot-web-server ctx))
+             (tt:is = 9030 (bot-web-port ctx))))
+      (delete-test-rows "test-bot-ctx"))))


### PR DESCRIPTION
## Summary
- `bot-context`'s `initialize-instance :after` used a `cond` that picked a single query branch and never fell through. When the nick+channel lookup returned zero rows, `web-server`/`web-port` stayed nil and `make-short-url-string` produced `http://NIL:NIL/…` URLs.
- Three common cases hit this: private messages (channel-name = bot's own nick), case-mismatched channel names, and channels missing from the `contexts` table.
- Restructure the lookup as an `or` chain of queries so the nick-only fallback runs when nick+channel returns nothing.
- Also make the `irc_channel` comparison case-insensitive to match IRC's on-the-wire semantics.

## Test plan
- [x] New `bot-context/exact-nick+channel-lookup` — sanity check
- [x] New `bot-context/channel-case-insensitive` — `#ChAn-Ctx` matches `#chan-ctx`
- [x] New `bot-context/pm-falls-through-to-nick-only` — channel-name = bot-nick populates from fallback
- [x] New `bot-context/unknown-channel-falls-through` — any channel not in DB falls through
- [x] Full suite: 139 passed, 0 failed (previously 131)

🅯 Brian O'Reilly <fade@deepsky.com>, 2026