### PR TITLE
Preserve web-port in non-localhost URL prefixes

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -153,12 +153,21 @@
     (jsown:parse quote)))
 
 (defun make-url-prefix (server-name server-port)
-  "Compose the portion of an URL encoding the server name and server port."
+  "Compose the portion of an URL encoding the server name and server port.
+The port must always appear in the emitted prefix unless it is the scheme's
+default port, because each connection-spec runs its own hunchentoot acceptor
+on its own port and the port is the only thing that distinguishes one
+channel's URL-shortener context from another when several connections share
+a single web-server-name."
   (cond
     ((string= server-name "localhost")
      (if (eql 80 server-port)
          (format nil "http://~A/" server-name)
          (format nil "http://~A:~A/" server-name server-port)))
+    ((eql 443 server-port)
+     (format nil "https://~A/" server-name))
+    (server-port
+     (format nil "https://~A:~A/" server-name server-port))
     (t
      (format nil "https://~A/" server-name))))
 


### PR DESCRIPTION
## Summary
- `make-url-prefix` (util.lisp) was dropping the port on any non-localhost hostname (regression from 6824977), collapsing every connection-spec's shortener to `https://host/HASH` and routing all short links onto whichever acceptor answered on the default port — the "main" one.
- Each connection-spec runs its own hunchentoot acceptor on its own `cs-web-port`, but `web-server-name` is a single config-level field, so the port is the only thing distinguishing one channel's URL-shortener context from another.
- Fix: always include the port in the emitted prefix unless it matches the scheme's default (80 for http on localhost, 443 for https).

## Test plan
- [x] Verified the six relevant cases standalone in SBCL: `localhost:5807`, `localhost:80`, `host.com:8888`, `host.com:5791`, `host.com:443`, `host.com:nil` all produce the expected URL.
- [x] `(ql:quickload :harlie)` compiles clean with no new warnings.
- [ ] Manual smoke test on a non-localhost deployment: paste URLs in two different channels on two different connection-specs and confirm the returned short links carry the correct per-connection port and resolve against the right acceptor.

🄯 Brian O'Reilly <fade@deepsky.com>, 2026