### PR TITLE
Fix URL-shortener scheme and port handling

### DIFF
--- a/config-template.lisp
+++ b/config-template.lisp
@@ -56,6 +56,13 @@ has a chaining database. shuffled for freshness.")
 ;;
 ;; On every startup, load-contexts syncs the database contexts table from
 ;; this list automatically.  No manual SQL is needed when adding channels.
+;;
+;; TLS for the URL-shortener web server is optional.  Pass :tls-cert-file
+;; and :tls-key-file to make-config with paths to a PEM certificate and its
+;; matching private key.  If both files exist and are readable at startup,
+;; the web servers come up as HTTPS and shortened URLs are emitted with an
+;; https:// scheme; otherwise the bot falls back to plain HTTP and http://
+;; URLs.  Leave the slots unset to run without TLS.
 ;; ---------------------------------------------------------------------------
 
 ;; Minimal example: one bot, one channel.

--- a/confobjects.lisp
+++ b/confobjects.lisp
@@ -77,6 +77,15 @@
 (defclass config ()
   ((db-credentials  :initarg :db-credentials  :accessor db-credentials)
    (web-server-name :initarg :web-server-name :accessor web-server-name)
+   (tls-cert-file   :initarg :tls-cert-file   :accessor tls-cert-file
+                    :initform nil
+                    :documentation "Path to a PEM certificate. When this and TLS-KEY-FILE both
+exist at web-server startup, the URL-shortener HTTP servers are
+brought up as HTTPS acceptors and shortened URLs are emitted with
+an https:// scheme.  When either is missing, plain HTTP is used.")
+   (tls-key-file    :initarg :tls-key-file    :accessor tls-key-file
+                    :initform nil
+                    :documentation "Path to the PEM private key that matches TLS-CERT-FILE.")
    (connections     :initarg :connections     :accessor connections)))
 
 (defun make-config (&rest args)

--- a/util.lisp
+++ b/util.lisp
@@ -154,22 +154,21 @@
 
 (defun make-url-prefix (server-name server-port)
   "Compose the portion of an URL encoding the server name and server port.
+The scheme (http vs https) follows *WEB-SCHEME*, which START-WEB-SERVERS
+sets at startup based on whether a usable TLS certificate is configured.
 The port must always appear in the emitted prefix unless it is the scheme's
 default port, because each connection-spec runs its own hunchentoot acceptor
 on its own port and the port is the only thing that distinguishes one
 channel's URL-shortener context from another when several connections share
 a single web-server-name."
-  (cond
-    ((string= server-name "localhost")
-     (if (eql 80 server-port)
-         (format nil "http://~A/" server-name)
-         (format nil "http://~A:~A/" server-name server-port)))
-    ((eql 443 server-port)
-     (format nil "https://~A/" server-name))
-    (server-port
-     (format nil "https://~A:~A/" server-name server-port))
-    (t
-     (format nil "https://~A/" server-name))))
+  (let* ((https-p (eq *web-scheme* :https))
+         (scheme (if https-p "https" "http"))
+         (default-port (if https-p 443 80)))
+    (cond
+      ((or (null server-port) (eql default-port server-port))
+       (format nil "~A://~A/" scheme server-name))
+      (t
+       (format nil "~A://~A:~A/" scheme server-name server-port)))))
 
 (defun make-pathname-in-homedir (fname)
   "Return a pathname relative to the user's home directory."

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -4,6 +4,28 @@
 
 (defparameter *acceptors* nil)
 
+(defparameter *web-scheme* :http
+  "Scheme used when composing shortened-URL prefixes.  START-WEB-SERVERS
+sets this to :HTTPS when *BOT-CONFIG* advertises a readable TLS cert/key
+pair, otherwise :HTTP.  Read by MAKE-URL-PREFIX.")
+
+(defun usable-tls-files (config)
+  "Return (CERT KEY) as pathnames when both files exist and are readable,
+or NIL when TLS should be skipped.  Missing or unreadable files silently
+degrade to plain HTTP rather than aborting startup."
+  (let ((cert (tls-cert-file config))
+        (key  (tls-key-file config)))
+    (when (and cert key)
+      (let ((cert-path (probe-file cert))
+            (key-path  (probe-file key)))
+        (cond
+          ((and cert-path key-path)
+           (list cert-path key-path))
+          (t
+           (log:warn "~&TLS cert/key configured but not found on disk (cert=~A key=~A); serving plain HTTP.~%"
+                     cert key)
+           nil))))))
+
 (defun make-webpage-listing-urls (store)
   "Generate HTML for the Web page listing the Web links in the database."
   (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
@@ -180,13 +202,23 @@ One acceptor is created and started per connection-spec in *BOT-CONFIG*."
   (glom-on-folder "/HyperSpec/" "HyperSpec/")
   (glom-on-folder "/gitrepo/" "harlie/.git/")
   (glom-on-prefix "/harlie.git" 'gitrepo-base-dispatch)
-  (dolist (cs (connections *bot-config*))
-    (let ((acceptor (make-instance 'hunchentoot:easy-acceptor
-                                   :port (cs-web-port cs)
-                                   :access-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-access.log")
-                                   :message-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-error.log"))))
-      (push acceptor *acceptors*)
-      (start acceptor))))
+  (let ((tls (usable-tls-files *bot-config*)))
+    (setf *web-scheme* (if tls :https :http))
+    (dolist (cs (connections *bot-config*))
+      (let ((acceptor
+              (if tls
+                  (make-instance 'hunchentoot:easy-ssl-acceptor
+                                 :port (cs-web-port cs)
+                                 :ssl-certificate-file (first tls)
+                                 :ssl-privatekey-file  (second tls)
+                                 :access-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-access.log")
+                                 :message-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-error.log"))
+                  (make-instance 'hunchentoot:easy-acceptor
+                                 :port (cs-web-port cs)
+                                 :access-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-access.log")
+                                 :message-log-destination (make-pathname-in-lisp-subdir "harlie/logs/http-error.log")))))
+        (push acceptor *acceptors*)
+        (start acceptor)))))
 
 (defun stop-web-servers ()
   "Shut down the web server subsystem."


### PR DESCRIPTION
## Summary
- Preserve the web-port in emitted URL prefixes for non-localhost hosts so each connection-spec's shortener context stays reachable.
- Choose http vs https based on whether a TLS cert/key pair is configured and readable at web-server startup; fall back to plain HTTP with a warning when either file is missing. The bot was previously emitting https:// links for a listener that never had TLS.
- Add optional \`:tls-cert-file\` / \`:tls-key-file\` config slots (documented in config-template) and stand up \`easy-ssl-acceptor\`s only when both files exist.

## Test plan
- [x] Start the bot with no TLS config; confirm shortened URLs come back as \`http://host:PORT/...\` and the web pages load.
- [x] Start the bot with a valid cert/key pair pointing at \`web-server-name\`; confirm shortened URLs come back as \`https://host:PORT/...\` and load under TLS.
- [x] Start the bot with \`:tls-cert-file\` set to a nonexistent path; confirm the warning fires and the bot degrades to plain HTTP instead of aborting.
- [x] Verify the per-channel context separation still works (each port still resolves to its own URL index).

🄯 Brian O'Reilly <fade@deepsky.com>, 2026