### PR TITLE
Add phrase voting feature

### DIFF
--- a/config-template.lisp
+++ b/config-template.lisp
@@ -53,6 +53,8 @@ has a chaining database. shuffled for freshness.")
 ;;   :web-port — port for the URL-shortener HTTP server       (required)
 ;;   :channel-key       — channel password, if any            (optional)
 ;;   :nickserv-password — NickServ IDENTIFY password, if any  (optional)
+;;   :public-port      — public port for URLs behind a reverse proxy (optional)
+;;                        e.g. 443 when Caddy/nginx terminates TLS
 ;;
 ;; On every startup, load-contexts syncs the database contexts table from
 ;; this list automatically.  No manual SQL is needed when adding channels.
@@ -91,11 +93,12 @@ has a chaining database. shuffled for freshness.")
      :nick "YourBotNick" :channel "#yourchannel"
      :nickserv-password "your-nickserv-password"
      :web-port 8888)
-    ;; Libera.Chat — second nick, open channel, no NickServ
+    ;; Libera.Chat — second nick, behind Caddy reverse proxy (public HTTPS)
     (make-connection-spec
      :server "irc.libera.chat" :ssl t
      :nick "AnotherNick" :channel "#anotherchannel"
-     :web-port 8889)
+     :web-port 8889
+     :public-port 443)
     ;; SRH.org — open channel
     (make-connection-spec
      :server "irc.srh.org" :ssl t

--- a/confobjects.lisp
+++ b/confobjects.lisp
@@ -66,7 +66,12 @@
    (extra-channels    :initarg :extra-channels    :accessor cs-extra-channels
                       :initform nil
                       :documentation "List of additional channels to join on this connection.")
-   (web-port          :initarg :web-port          :accessor cs-web-port)))
+   (web-port          :initarg :web-port          :accessor cs-web-port)
+   (public-port       :initarg :public-port       :accessor cs-public-port
+                      :initform nil
+                      :documentation "Public-facing port for URL generation when behind a reverse
+proxy (e.g. 443 for Caddy/nginx with TLS).  When NIL the web-port is
+used, preserving the current behaviour for direct-access setups.")))
 
 (defun make-connection-spec (&rest args)
   (apply #'make-instance 'connection-spec args))

--- a/context.lisp
+++ b/context.lisp
@@ -8,6 +8,7 @@
    (bot-irc-channel :initarg :bot-irc-channel :initform nil :accessor bot-irc-channel)
    (bot-web-server :initarg :bot-web-server :initform nil :accessor bot-web-server)
    (bot-web-port :initarg :bot-web-port :initform nil :accessor bot-web-port)
+   (bot-public-port :initform nil :accessor bot-public-port)
    (bot-uri-prefix :initarg :bot-uri-prefix :initform nil :accessor bot-uri-prefix)))
 
 (defmethod initialize-instance :after ((context bot-context) &key)
@@ -57,7 +58,13 @@
             (setf (bot-irc-channel context) (third conlist))
             (setf (bot-web-server context) (fourth conlist))
             (setf (bot-web-port context) (fifth conlist))
-            (setf (bot-uri-prefix context) (sixth conlist)))))
+            (setf (bot-uri-prefix context) (sixth conlist))
+            ;; Look up public-port from config (reverse-proxy support).
+            (when (and *bot-config* (bot-web-port context))
+              (dolist (cs (connections *bot-config*))
+                (when (eql (cs-web-port cs) (bot-web-port context))
+                  (setf (bot-public-port context) (cs-public-port cs))
+                  (return)))))))
     (error (e)
       (log:warn "~&[CONTEXT] DB lookup failed, using partial context: ~A" e))))
 

--- a/database/add-phrases-tables.sql
+++ b/database/add-phrases-tables.sql
@@ -31,4 +31,20 @@ CREATE TABLE IF NOT EXISTS public.phrase_votes (
 CREATE INDEX IF NOT EXISTS phrase_votes_phrase_idx
     ON public.phrase_votes (phrase_id);
 
+-- Transfer ownership to the database owner so the bot user can
+-- read/write these tables even when the migration is run as postgres.
+DO $$
+DECLARE
+    db_owner text;
+BEGIN
+    SELECT pg_catalog.pg_get_userbyid(d.datdba) INTO db_owner
+      FROM pg_catalog.pg_database d
+     WHERE d.datname = current_database();
+
+    EXECUTE format('ALTER TABLE public.phrases OWNER TO %I', db_owner);
+    EXECUTE format('ALTER TABLE public.phrase_votes OWNER TO %I', db_owner);
+    EXECUTE format('ALTER SEQUENCE public.phrases_phrase_id_seq OWNER TO %I', db_owner);
+END
+$$;
+
 COMMIT;

--- a/database/add-phrases-tables.sql
+++ b/database/add-phrases-tables.sql
@@ -1,0 +1,34 @@
+-- add-phrases-tables.sql
+-- Migration: add the phrases and phrase_votes tables.
+-- Run once against an existing Harlie database:
+--
+--   psql -U <bot_user> -d <bot_db> -f database/add-phrases-tables.sql
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.phrases (
+    phrase_id  serial       PRIMARY KEY,
+    context_id integer      NOT NULL REFERENCES public.contexts(context_id),
+    channel    text         NOT NULL,
+    trigger_text text,
+    phrase_text  text       NOT NULL,
+    created_at timestamptz  DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS phrases_context_idx
+    ON public.phrases (context_id);
+
+CREATE INDEX IF NOT EXISTS phrases_channel_idx
+    ON public.phrases (channel);
+
+CREATE TABLE IF NOT EXISTS public.phrase_votes (
+    phrase_id  integer      NOT NULL REFERENCES public.phrases(phrase_id) ON DELETE CASCADE,
+    voter      text         NOT NULL,
+    voted_at   timestamptz  DEFAULT now(),
+    PRIMARY KEY (phrase_id, voter)
+);
+
+CREATE INDEX IF NOT EXISTS phrase_votes_phrase_idx
+    ON public.phrase_votes (phrase_id);
+
+COMMIT;

--- a/database/bot-schema.sql.template
+++ b/database/bot-schema.sql.template
@@ -329,6 +329,57 @@ ALTER SEQUENCE public.quotes_quote_id_seq OWNED BY public.quotes.quote_id;
 
 
 --
+-- Name: phrases; Type: TABLE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE TABLE public.phrases (
+    phrase_id integer NOT NULL,
+    context_id integer NOT NULL,
+    channel text NOT NULL,
+    trigger_text text,
+    phrase_text text NOT NULL,
+    created_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.phrases OWNER TO <bot_runner_uid>;
+
+--
+-- Name: phrases_phrase_id_seq; Type: SEQUENCE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE SEQUENCE public.phrases_phrase_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.phrases_phrase_id_seq OWNER TO <bot_runner_uid>;
+
+--
+-- Name: phrases_phrase_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER SEQUENCE public.phrases_phrase_id_seq OWNED BY public.phrases.phrase_id;
+
+
+--
+-- Name: phrase_votes; Type: TABLE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE TABLE public.phrase_votes (
+    phrase_id integer NOT NULL,
+    voter text NOT NULL,
+    voted_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.phrase_votes OWNER TO <bot_runner_uid>;
+
+--
 -- Name: bot_channel bot_channel_id; Type: DEFAULT; Schema: public; Owner: <bot_runner_uid>
 --
 
@@ -378,6 +429,13 @@ ALTER TABLE ONLY public.quotes ALTER COLUMN quote_id SET DEFAULT nextval('public
 
 
 --
+-- Name: phrases phrase_id; Type: DEFAULT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.phrases ALTER COLUMN phrase_id SET DEFAULT nextval('public.phrases_phrase_id_seq'::regclass);
+
+
+--
 -- Name: bot_channel bot_channel_channel_name_key; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
 --
 
@@ -407,6 +465,22 @@ ALTER TABLE ONLY public.channel_user
 
 ALTER TABLE ONLY public.quotes
     ADD CONSTRAINT quotes_pkey PRIMARY KEY (quote_id);
+
+
+--
+-- Name: phrases phrases_pkey; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.phrases
+    ADD CONSTRAINT phrases_pkey PRIMARY KEY (phrase_id);
+
+
+--
+-- Name: phrase_votes phrase_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.phrase_votes
+    ADD CONSTRAINT phrase_votes_pkey PRIMARY KEY (phrase_id, voter);
 
 
 --
@@ -510,6 +584,27 @@ CREATE INDEX words_prefixes_idx ON public.words USING btree (upper(word1), upper
 
 
 --
+-- Name: phrases_context_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX phrases_context_idx ON public.phrases USING btree (context_id);
+
+
+--
+-- Name: phrases_channel_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX phrases_channel_idx ON public.phrases USING btree (channel);
+
+
+--
+-- Name: phrase_votes_phrase_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX phrase_votes_phrase_idx ON public.phrase_votes USING btree (phrase_id);
+
+
+--
 -- Name: channel_user channel_user_channel_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
 --
 
@@ -539,6 +634,22 @@ ALTER TABLE ONLY public.urls
 
 ALTER TABLE ONLY public.words
     ADD CONSTRAINT words_context_id_fkey FOREIGN KEY (context_id) REFERENCES public.contexts(context_id);
+
+
+--
+-- Name: phrases phrases_context_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.phrases
+    ADD CONSTRAINT phrases_context_id_fkey FOREIGN KEY (context_id) REFERENCES public.contexts(context_id);
+
+
+--
+-- Name: phrase_votes phrase_votes_phrase_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.phrase_votes
+    ADD CONSTRAINT phrase_votes_phrase_id_fkey FOREIGN KEY (phrase_id) REFERENCES public.phrases(phrase_id) ON DELETE CASCADE;
 
 
 --

--- a/harlie.asd
+++ b/harlie.asd
@@ -62,6 +62,7 @@
 	       (:file "url-store")
 	       (:file "irc-client")
 	       (:file "memo")
+	       (:file "phrases")
 
 	       (:file "constants")
 	       (:file "chainer")

--- a/init-first-run.lisp
+++ b/init-first-run.lisp
@@ -65,7 +65,8 @@ the table ownership, and excecute the schema."
     (execute-file sqlfile)))
 
 (defun initialize-startup-maybe (&key (go? nil))
-  (let* ((db-schema (merge-pathnames *here-db* "bot-schema.sql")))
+  (let* ((db-template (merge-pathnames *here-db* "bot-schema.sql.template"))
+         (db-schema   (merge-pathnames *here-db* "bot-schema.sql")))
     (handler-case
         (with-connection (db-credentials *bot-config*)
           (select-dao 'harlie-user))
@@ -74,6 +75,7 @@ the table ownership, and excecute the schema."
         (log:info "Creating database to stand up the bot...")
         (uiop:run-program (list "createdb" (first (db-credentials *bot-config*))) :output t)
         (log:info "Creating tables for the various required users...")
+        (uiop:copy-file db-template db-schema)
         (make-base-tables db-schema)))
     ;; Sync contexts table from config on every startup.
     (when go?

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -384,7 +384,20 @@ allowing for leading and trailing punctuation characters in the match."
 		     (when trigger-tokens
 		       (let ((outgoing (chain context (first trigger-tokens) (second trigger-tokens))))
 		         (unless (not (mismatch trigger-tokens outgoing :test #'string-equal))
-		           (irc-reply (format nil "~{~A~^ ~}" outgoing)))))))
+			   (let* ((phrase-text (format nil "~{~A~^ ~}" outgoing))
+				  (phrase-id
+				    (handler-case
+					(db-store-phrase
+					 (chain-write-context-id context)
+					 channel-name
+					 (format nil "~{~A~^ ~}" token-text-list)
+					 phrase-text)
+				      (error (e)
+					(log:warn "~&[PHRASE] Failed to store phrase: ~A" e)
+					nil))))
+			     (if phrase-id
+				 (irc-reply (format nil "[#~D] ~A" phrase-id phrase-text))
+				 (irc-reply phrase-text))))))))
 	          (t nil)))))
     (error (e)
       (log:warn "~&[MSG-HOOK] Error processing message from ~A in ~A: ~A"

--- a/phrases.lisp
+++ b/phrases.lisp
@@ -1,0 +1,105 @@
+;;;; phrases.lisp — Bot phrase storage and voting
+;;
+;; Every Markov-chain utterance is persisted so that channel members
+;; can vote for the funniest ones.  The top-voted phrases are
+;; available via the !top command and a /phrases web endpoint.
+
+(in-package #:harlie)
+
+;;; ---- Database operations ------------------------------------------------
+
+(defun db-store-phrase (context-id channel trigger-text phrase-text)
+  "Persist a bot-generated phrase.  Returns the new phrase_id."
+  (with-connection (db-credentials *bot-config*)
+    (query (:insert-into 'phrases :set
+            'context-id  context-id
+            'channel     channel
+            'trigger-text trigger-text
+            'phrase-text  phrase-text)
+           :none)
+    (query (:select (:raw "currval('phrases_phrase_id_seq')")) :single)))
+
+(defun db-vote-phrase (phrase-id voter)
+  "Cast a vote for PHRASE-ID by VOTER.
+Returns :ok, :already-voted, or :not-found."
+  (with-connection (db-credentials *bot-config*)
+    (let ((exists (query (:select 'phrase-id :from 'phrases
+                          :where (:= 'phrase-id phrase-id))
+                         :single)))
+      (cond
+        ((null exists) :not-found)
+        (t (handler-case
+               (progn
+                 (query (:insert-into 'phrase-votes :set
+                         'phrase-id phrase-id
+                         'voter     voter)
+                        :none)
+                 :ok)
+             ;; unique violation (PG 23505) means already voted
+             (database-error (e)
+               (if (string= "23505" (cl-postgres::database-error-code e))
+                   :already-voted
+                   (error e)))))))))
+
+(defun db-get-phrase (phrase-id)
+  "Retrieve a phrase by ID.  Returns (phrase-id channel trigger phrase vote-count) or NIL."
+  (with-connection (db-credentials *bot-config*)
+    (first
+     (query (:select 'p.phrase-id 'p.channel 'p.trigger-text 'p.phrase-text
+                     (:raw "COALESCE(v.votes, 0) AS vote_count")
+             :from (:as 'phrases 'p)
+             :left-join (:as (:select 'phrase-id (:as (:count '*) 'votes)
+                              :from 'phrase-votes
+                              :group-by 'phrase-id)
+                             'v)
+             :on (:= 'p.phrase-id 'v.phrase-id)
+             :where (:= 'p.phrase-id phrase-id))
+            :rows))))
+
+(defun db-top-phrases (channel &optional (limit 10))
+  "Return the top voted phrases for CHANNEL.
+Each row is (phrase-id trigger-text phrase-text vote-count)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'p.phrase-id 'p.trigger-text 'p.phrase-text
+                      (:raw "COALESCE(v.votes, 0) AS vote_count")
+              :from (:as 'phrases 'p)
+              :left-join (:as (:select 'phrase-id (:as (:count '*) 'votes)
+                               :from 'phrase-votes
+                               :group-by 'phrase-id)
+                              'v)
+              :on (:= 'p.phrase-id 'v.phrase-id)
+              :where (:= 'p.channel channel))
+             (:desc (:raw "vote_count")) (:desc 'p.phrase-id))
+            limit)
+           :rows)))
+
+(defun db-top-phrases-for-web (context-id &optional (limit 50))
+  "Return the top voted phrases for a context (used by the web endpoint).
+Each row is (phrase-id channel trigger-text phrase-text vote-count created-at)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'p.phrase-id 'p.channel 'p.trigger-text 'p.phrase-text
+                      (:raw "COALESCE(v.votes, 0) AS vote_count")
+                      'p.created-at
+              :from (:as 'phrases 'p)
+              :left-join (:as (:select 'phrase-id (:as (:count '*) 'votes)
+                               :from 'phrase-votes
+                               :group-by 'phrase-id)
+                              'v)
+              :on (:= 'p.phrase-id 'v.phrase-id)
+              :where (:= 'p.context-id context-id))
+             (:desc (:raw "vote_count")) (:desc 'p.phrase-id))
+            limit)
+           :rows)))
+
+(defun db-phrase-vote-count (phrase-id)
+  "Return the number of votes for PHRASE-ID."
+  (with-connection (db-credentials *bot-config*)
+    (or (query (:select (:count '*)
+               :from 'phrase-votes
+               :where (:= 'phrase-id phrase-id))
+              :single)
+        0)))

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -950,6 +950,77 @@ Returns :ok, :not-found, or :not-owner."
                   :name (format nil "reminder-~A" sender))
                  (format nil "⏰  Got it, I'll remind you in ~A." (format-duration seconds)))))))))
 
+;;; ============================================================
+;;; Phrase voting (issue #1)
+;;; ============================================================
+
+(defplugin vote (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Vote for a bot phrase. Usage: !vote <phrase-id>")
+    (:priority 1.5)
+    (:run (let* ((tokens (plugin-token-text-list plug-request))
+                 (id-str (second tokens))
+                 (id (when id-str (parse-integer id-str :junk-allowed t)))
+                 (voter (prefix-nick (parse-prefix
+                                      (message-prefix
+                                       (last-message (plugin-conn plug-request)))))))
+            (cond
+              ((null id) "Usage: !vote <phrase-id>")
+              (t (handler-case
+                     (let ((result (db-vote-phrase id voter)))
+                       (case result
+                         (:ok
+                          (let ((count (db-phrase-vote-count id)))
+                            (format nil "🗳  Vote recorded for phrase #~D (~D vote~:P total)." id count)))
+                         (:already-voted
+                          (format nil "You've already voted for phrase #~D." id))
+                         (:not-found
+                          (format nil "No phrase #~D found." id))))
+                   (error (e)
+                     (format nil "Error voting: ~A" e)))))))))
+
+(defplugin top (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Show the top-voted bot phrases. Usage: !top [count] (also see /phrases)")
+    (:priority 1.5)
+    (:run (let* ((tokens (plugin-token-text-list plug-request))
+                 (n-str (second tokens))
+                 (n (if n-str (or (parse-integer n-str :junk-allowed t) 5) 5))
+                 (n (min n 10))
+                 (channel (plugin-channel-name plug-request)))
+            (handler-case
+                (let ((rows (db-top-phrases channel n)))
+                  (if rows
+                      (loop for row in rows
+                            for (pid trigger phrase votes) = row
+                            collect (format nil "#~D [~D vote~:P] ~A"
+                                            pid votes phrase))
+                      "No phrases have been voted on yet."))
+              (error (e)
+                (format nil "Error fetching top phrases: ~A" e)))))))
+
+(defplugin phrase (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Look up a specific phrase by ID. Usage: !phrase <id>")
+    (:priority 1.5)
+    (:run (let* ((tokens (plugin-token-text-list plug-request))
+                 (id-str (second tokens))
+                 (id (when id-str (parse-integer id-str :junk-allowed t))))
+            (cond
+              ((null id) "Usage: !phrase <id>")
+              (t (handler-case
+                     (let ((row (db-get-phrase id)))
+                       (if row
+                           (let ((pid (first row))
+                                 (trigger (third row))
+                                 (phrase (fourth row))
+                                 (votes (fifth row)))
+                             (format nil "#~D [~D vote~:P] ~A~@[ ← \"~A\"~]"
+                                     pid votes phrase trigger))
+                           (format nil "No phrase #~D found." id)))
+                   (error (e)
+                     (format nil "Error: ~A" e)))))))))
+
 ;;; !eval removed — "this plugin is too dangerous to live" -Fade
 
 ;; ===[ hyperspace motivator follows. ]===

--- a/url-store.lisp
+++ b/url-store.lisp
@@ -179,7 +179,8 @@ Return the short URL and title, or existing values if already stored."))
 
 (defun make-short-url-string (context hash)
   "Compose the short URL string for a given hash in a given context."
-  (format nil "~A~A" (make-url-prefix (bot-web-server context) (bot-web-port context)) hash))
+  (let ((port (or (bot-public-port context) (bot-web-port context))))
+    (format nil "~A~A" (make-url-prefix (bot-web-server context) port) hash)))
 
 (defmethod lookup-url ((store postmodern-url-store) context url nick)
   (let ((result (with-connection (readwrite-url-db store)

--- a/util.lisp
+++ b/util.lisp
@@ -161,7 +161,7 @@ default port, because each connection-spec runs its own hunchentoot acceptor
 on its own port and the port is the only thing that distinguishes one
 channel's URL-shortener context from another when several connections share
 a single web-server-name."
-  (let* ((https-p (eq *web-scheme* :https))
+  (let* ((https-p (or (eq *web-scheme* :https) (eql server-port 443)))
          (scheme (if https-p "https" "http"))
          (default-port (if https-p 443 80)))
     (cond

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -99,6 +99,46 @@ or an error message, as appropriate."
 	(let ((page (make-webpage-listing-urls *the-url-store*)))
 	  (values (format nil "~A" page))))))
 
+(defun make-webpage-listing-phrases ()
+  "Generate HTML for the top-voted bot phrases."
+  (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
+         (bothandle (bot-nick context))
+         (channel (bot-irc-channel context))
+         (ctx-id (chain-read-context-id context)))
+    (spinneret:with-html-string
+      (:html
+       (:head
+        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
+        (:title (format nil "Top phrases for ~A on ~A" bothandle channel)))
+       (:body
+        (:h2 (format nil "Top phrases for ~A on ~A" bothandle channel))
+        (:p "Vote for phrases on IRC with " (:code "!vote <id>"))
+        (:br)
+        (let ((rows (handler-case (db-top-phrases-for-web ctx-id 50)
+                      (error (e)
+                        (declare (ignore e))
+                        nil))))
+          (if rows
+              (:table
+               (:thead
+                (:tr (:th "#") (:th "Votes") (:th "Phrase") (:th "Trigger")))
+               (:tbody
+                (dolist (row rows)
+                  (let ((pid (first row))
+                        (trigger (third row))
+                        (phrase (fourth row))
+                        (votes (fifth row)))
+                    (:tr
+                     (:td (format nil "~D" pid))
+                     (:td (format nil "~D" votes))
+                     (:td phrase)
+                     (:td (or trigger "")))))))
+              (:p "No phrases yet."))))))))
+
+(defun phrases-dispatch ()
+  "Dispatcher for the top-phrases page."
+  (make-webpage-listing-phrases))
+
 (defun html-apology ()
   "Return HTML for a page explaining that a browser has struck out."
   (spinneret:with-html-string
@@ -197,6 +237,7 @@ One acceptor is created and started per connection-spec in *BOT-CONFIG*."
   (glom-on-prefix "/ass/" 'ass-url-index)
   (glom-on-static-file "/robots.txt" "harlie/robots.txt")
   (glom-on-regex "^/help/?$" 'help-dispatch)
+  (glom-on-regex "^/phrases/?$" 'phrases-dispatch)
   (glom-on-regex "^/source" 'source-dispatch)
   (glom-on-regex "^/hyper(spec)?/?$" 'hyperspec-base-dispatch)
   (glom-on-folder "/HyperSpec/" "HyperSpec/")


### PR DESCRIPTION
Implements the feature request from issue #1 — allow channel members to vote for top bot phrases.

## What it does

Every Markov-chain utterance the bot generates is stored in a new `phrases` table with a serial `phrase_id`. The bot prefixes each utterance with `[#id]` so channel members can reference it.

### New IRC commands
- **`!vote <id>`** — vote for a phrase (one vote per user, idempotent)
- **`!top [n]`** — show the top-voted phrases for the current channel (max 10)
- **`!phrase <id>`** — look up a specific phrase with its vote count and trigger context

### New web endpoint
- **`/phrases`** — HTML table of top-voted phrases, styled with PicoCSS

All three commands auto-appear in `!help` and the `/help` web page via the existing plugin system.

## Database changes
- New tables: `phrases`, `phrase_votes`
- Migration script: `database/add-phrases-tables.sql` (run once for existing installs)
- Schema template updated for fresh installs

## Reverse proxy support
Adds an optional `:public-port` field to `connection-spec`. When set (e.g. `:public-port 443`), generated URLs use that port and its implied scheme instead of the hunchentoot listen port. This produces clean `https://host/path` URLs for setups behind Caddy/nginx. When omitted, behaviour is unchanged — the listen port appears in URLs as before.

## Files
- **New:** `phrases.lisp`, `database/add-phrases-tables.sql`
- **Modified:** `harlie.asd`, `irc-client.lisp`, `plugins.lisp`, `web-server.lisp`, `database/bot-schema.sql.template`, `confobjects.lisp`, `context.lisp`, `url-store.lisp`, `util.lisp`, `config-template.lisp`

Closes #1