### PR TITLE
fix(migration): derive owner from harlie schema, not the database

### DIFF
--- a/database/add-phrases-tables.sql
+++ b/database/add-phrases-tables.sql
@@ -31,19 +31,30 @@ CREATE TABLE IF NOT EXISTS public.phrase_votes (
 CREATE INDEX IF NOT EXISTS phrase_votes_phrase_idx
     ON public.phrase_votes (phrase_id);
 
--- Transfer ownership to the database owner so the bot user can
--- read/write these tables even when the migration is run as postgres.
+-- Transfer ownership to whichever role already owns the rest of the
+-- harlie schema, so the bot user can read/write these tables even when
+-- the migration is run as postgres.  We pick the owner of public.contexts
+-- (the FK target above, guaranteed to exist by this point) rather than
+-- the database owner, because on installs where the database itself is
+-- owned by postgres but the harlie tables are owned by the bot user
+-- the datdba lookup picks postgres and the migration cannot be applied
+-- as the bot user.
 DO $$
 DECLARE
-    db_owner text;
+    schema_owner text;
 BEGIN
-    SELECT pg_catalog.pg_get_userbyid(d.datdba) INTO db_owner
-      FROM pg_catalog.pg_database d
-     WHERE d.datname = current_database();
+    SELECT tableowner INTO schema_owner
+      FROM pg_catalog.pg_tables
+     WHERE schemaname = 'public'
+       AND tablename  = 'contexts';
 
-    EXECUTE format('ALTER TABLE public.phrases OWNER TO %I', db_owner);
-    EXECUTE format('ALTER TABLE public.phrase_votes OWNER TO %I', db_owner);
-    EXECUTE format('ALTER SEQUENCE public.phrases_phrase_id_seq OWNER TO %I', db_owner);
+    IF schema_owner IS NULL THEN
+        RAISE EXCEPTION 'cannot determine harlie schema owner: public.contexts not found';
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.phrases OWNER TO %I', schema_owner);
+    EXECUTE format('ALTER TABLE public.phrase_votes OWNER TO %I', schema_owner);
+    EXECUTE format('ALTER SEQUENCE public.phrases_phrase_id_seq OWNER TO %I', schema_owner);
 END
 $$;
 


### PR DESCRIPTION
## Summary

`database/add-phrases-tables.sql` now picks the owner of `public.contexts` (the FK target of `phrases.context_id`) instead of the owner of the database itself.

## Motivation

The existing migration's `DO` block calls `pg_get_userbyid(d.datdba)` to find an owner for the new tables. On installs where `botdb` is owned by `postgres` but every harlie table is owned by the bot user — for example, the deepsky production bot — that lookup picks `postgres`, and the subsequent `ALTER TABLE ... OWNER TO postgres` requires the runner to be a member of role `postgres`.

Concretely, on a bot where the existing schema is owned by `semaphor` but the database is owned by `postgres`:

```
semaphor@host:~$ psql botdb < add-phrases-tables.sql
BEGIN
CREATE TABLE
…
ERROR:  must be member of role "postgres"
CONTEXT:  SQL statement "ALTER TABLE public.phrases OWNER TO postgres"
ROLLBACK
```

Running as `postgres` instead succeeds, but leaves the new tables owned by `postgres` — inconsistent with the rest of the schema, including the FK target.

The new lookup reads `tableowner` from `pg_tables` for `public.contexts`. Since `phrases.context_id` references `contexts(context_id)`, that table must exist by the time the `DO` block runs; its owner is the role that owns the rest of the harlie schema, which is exactly what the new tables should match. If `contexts` is missing, the migration raises a clear exception instead of silently picking the wrong owner.

`bot-schema.sql.template` already uses the `<bot_runner_uid>` placeholder substituted at first-run time, so new installs are unaffected by this change.

## Test plan

- [x] Verified the broken behaviour reproduces on the deepsky production bot (`semaphor`/`botdb`, DB owned by `postgres`, tables owned by `semaphor`).
- [x] Applied the equivalent fix manually on that bot; `phrases` and `phrase_votes` are now owned by `semaphor`, with PK / FK / indexes intact.
- [ ] Confirm migration applies cleanly on a fresh database where the bot user owns both DB and tables (the common case) — owner lookup should still resolve to the bot user via `contexts`.

🄯 Brian O'Reilly <fade@deepsky.com>, 2026