### PR TITLE
Bulletin board, unified web theme and per-channel fix

### DIFF
--- a/context.lisp
+++ b/context.lisp
@@ -42,11 +42,26 @@
                   (append context-query-head
                           `(:where (:= (:raw "lower(context_name)")
                                        ,(string-downcase (bot-nick context)))))))
+               ;; When several channels share one connection-spec they share
+               ;; a single web port, so the port alone cannot disambiguate
+               ;; them.  When a caller (e.g. a !board URL) supplies both the
+               ;; port and the channel, match on both to pin the exact row.
+               (web-port+channel-query
+                (when (and (bot-web-port context)
+                           (bot-irc-channel context)
+                           (stringp (bot-irc-channel context)))
+                  (append context-query-head
+                          `(:where (:and
+                                    (:= 'web-port ,(bot-web-port context))
+                                    (:= (:raw "lower(irc_channel)")
+                                        ,(string-downcase (bot-irc-channel context))))))))
                (web-port-query
                 (when (bot-web-port context)
                   (append context-query-head
                           `(:where (:= 'web-port ,(bot-web-port context))))))
-               (conlist (or (and nick+channel-query
+               (conlist (or (and web-port+channel-query
+                                 (first (query (sql-compile web-port+channel-query))))
+                            (and nick+channel-query
                                  (first (query (sql-compile nick+channel-query))))
                             (and nick-only-query
                                  (first (query (sql-compile nick-only-query))))

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -403,20 +403,19 @@ allowing for leading and trailing punctuation characters in the match."
 		     (when trigger-tokens
 		       (let ((outgoing (chain context (first trigger-tokens) (second trigger-tokens))))
 		         (unless (not (mismatch trigger-tokens outgoing :test #'string-equal))
-			   (let* ((phrase-text (format nil "~{~A~^ ~}" outgoing))
-				  (phrase-id
-				    (handler-case
-					(db-store-phrase
-					 (chain-write-context-id context)
-					 channel-name
-					 (format nil "~{~A~^ ~}" token-text-list)
-					 phrase-text)
-				      (error (e)
-					(log:warn "~&[PHRASE] Failed to store phrase: ~A" e)
-					nil))))
-			     (if phrase-id
-				 (irc-reply (format nil "[#~D] ~A" phrase-id phrase-text))
-				 (irc-reply phrase-text))))))))
+			   (let ((phrase-text (format nil "~{~A~^ ~}" outgoing)))
+			     ;; Persist the phrase silently so it can be voted on
+			     ;; later by relative offset (!vote, !vote -N).  We no
+			     ;; longer publish the [#id] marker on every utterance.
+			     (handler-case
+				 (db-store-phrase
+				  (chain-write-context-id context)
+				  channel-name
+				  (format nil "~{~A~^ ~}" token-text-list)
+				  phrase-text)
+			       (error (e)
+				 (log:warn "~&[PHRASE] Failed to store phrase: ~A" e)))
+			     (irc-reply phrase-text)))))))
 	          (t nil)))))
     (error (e)
       (log:warn "~&[MSG-HOOK] Error processing message from ~A in ~A: ~A"

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -248,6 +248,9 @@ allowing for leading and trailing punctuation characters in the match."
 					 (- 10 (length (trigger-list channel)))
 					 #'acceptable-word-p)))
 	     token-list))
+	  ((< (random 1.0) *spontaneous-reply-chance*)
+	   (log:debug "[~&in triggered] spontaneous reply fired~%")
+	   token-list)
 	  (t nil))))
 
 (defun extract-urls (text)
@@ -415,7 +418,7 @@ allowing for leading and trailing punctuation characters in the match."
 				  phrase-text)
 			       (error (e)
 				 (log:warn "~&[PHRASE] Failed to store phrase: ~A" e)))
-			     (irc-reply phrase-text)))))))
+			     (irc-reply (maybe-snarkify phrase-text))))))))
 	          (t nil)))))
     (error (e)
       (log:warn "~&[MSG-HOOK] Error processing message from ~A in ~A: ~A"

--- a/phrases.lisp
+++ b/phrases.lisp
@@ -103,3 +103,33 @@ Each row is (phrase-id channel trigger-text phrase-text vote-count created-at)."
                :where (:= 'phrase-id phrase-id))
               :single)
         0)))
+
+(defun db-recent-phrases (channel &optional (limit 20))
+  "Return the most recent phrases for CHANNEL, newest first.
+Each row is (phrase-id phrase-text vote-count)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'p.phrase-id 'p.phrase-text
+                      (:raw "COALESCE(v.votes, 0) AS vote_count")
+              :from (:as 'phrases 'p)
+              :left-join (:as (:select 'phrase-id (:as (:count '*) 'votes)
+                               :from 'phrase-votes
+                               :group-by 'phrase-id)
+                              'v)
+              :on (:= 'p.phrase-id 'v.phrase-id)
+              :where (:= 'p.channel channel))
+             (:desc 'p.phrase-id))
+            limit)
+           :rows)))
+
+(defun db-nth-recent-phrase-id (channel offset)
+  "Return the phrase-id OFFSET positions back in CHANNEL (0 = newest), or NIL."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'phrase-id :from 'phrases
+              :where (:= 'channel channel))
+             (:desc 'phrase-id))
+            1 offset)
+           :single)))

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -1039,8 +1039,13 @@ Returns a user-facing status string."
   (case (plugin-action plug-request)
     (:docstring "Show the bulletin board of top phrases and quotes. Usage: !board")
     (:priority 1.5)
-    (:run (format nil "📋  Bulletin board: ~A"
-                  (make-short-url-string (plugin-context plug-request) "board")))))
+    (:run (let* ((context (plugin-context plug-request))
+                 (channel (bot-irc-channel context))
+                 (hash (if (and channel (stringp channel))
+                           (format nil "board?c=~A" (url-encode channel))
+                           "board")))
+            (format nil "📋  Bulletin board: ~A"
+                    (make-short-url-string context hash))))))
 
 (defplugin links (plug-request)
   (case (plugin-action plug-request)

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -844,6 +844,19 @@ Returns :ok, :not-found, or :not-owner."
                       :row)))
       row)))
 
+(defun db-recent-quotes-for-web (channel &optional (limit 50))
+  "Return the most recent quotes for CHANNEL, newest first.
+Each row is (quote-id added-by quote-text added-at)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'quote-id 'added-by 'quote-text 'added-at
+              :from 'quotes
+              :where (:= 'channel channel))
+             (:desc 'quote-id))
+            limit)
+           :rows)))
+
 (defplugin addquote (plug-request)
   (case (plugin-action plug-request)
     (:docstring "Save a channel quote. Usage: !addquote <text>")
@@ -1016,7 +1029,7 @@ Returns a user-facing status string."
 
 (defplugin top (plug-request)
   (case (plugin-action plug-request)
-    (:docstring "Show the top-voted bot phrases. Usage: !top [count] (also see /phrases)")
+    (:docstring "Show the top-voted bot phrases. Usage: !top [count] (web view: !board)")
     (:priority 1.5)
     (:run (let* ((tokens (plugin-token-text-list plug-request))
                  (n-str (second tokens))
@@ -1033,6 +1046,13 @@ Returns a user-facing status string."
                       "No phrases have been voted on yet."))
               (error (e)
                 (format nil "Error fetching top phrases: ~A" e)))))))
+
+(defplugin board (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Show the bulletin board of top phrases and quotes. Usage: !board")
+    (:priority 1.5)
+    (:run (format nil "📋  Bulletin board: ~A"
+                  (make-short-url-string (plugin-context plug-request) "board")))))
 
 (defplugin phrase (plug-request)
   (case (plugin-action plug-request)

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -229,26 +229,14 @@
   "Return HTML for a page giving help with the bot's plugin commands."
   (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
          (bothandle (bot-nick context)))
-    (spinneret:with-html-string
-      (:html
-       (:head
-        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
-        (:title (format nil "~A Help Page" bothandle)))
-       (:body
-        (:h1 (format nil "~A Help Page" bothandle))
-        (:dl
-         (let ((oldpriority 0.0))
-           (dolist (doc (sort (plugin-docs) 'sort-docs))
-             (multiple-value-bind (n f) (floor (third doc))
-               (declare (ignore n))
-               (log:debug "~A ~A~%" oldpriority (third doc))
-               (if (> (third doc) 0.0)
-                   (progn
-                     (when (and (< oldpriority (third doc)) (= f 0.0))
-                       (:br))
-                     (:dt (:b (format nil "!~A:" (first doc))))
-                     (:dd (format nil "~A" (second doc)))
-                     (setf oldpriority (third doc)))))))))))))
+    (with-bot-page (:title (format nil "~A command reference" bothandle)
+                    :subtitle "Every command the bot answers to. Prefix each with ! in channel.")
+      (:section :class "panel"
+        (:dl :class "help"
+          (dolist (doc (sort (plugin-docs) 'sort-docs))
+            (when (> (third doc) 0.0)
+              (:dt (format nil "!~A" (first doc)))
+              (:dd (format nil "~A" (second doc))))))))))
 
 (defplugin 8ball (plug-request)
   (case (plugin-action plug-request)

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -1042,6 +1042,13 @@ Returns a user-facing status string."
     (:run (format nil "📋  Bulletin board: ~A"
                   (make-short-url-string (plugin-context plug-request) "board")))))
 
+(defplugin links (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Show the index of links recorded in this channel. Usage: !links")
+    (:priority 1.5)
+    (:run (format nil "🔗  Links index: ~A"
+                  (make-short-url-string (plugin-context plug-request) "")))))
+
 (defplugin phrase (plug-request)
   (case (plugin-action plug-request)
     (:docstring "Look up a specific phrase by ID. Usage: !phrase <id>")

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -25,7 +25,7 @@
 		 :plugin-name "DOUBLEHELP"
 		 :plugin-hook #'(lambda (plug-request)
 				  (cond ((eq (plugin-action plug-request) :docstring)
-					 (list (format nil "Sorry, I don't recognize that command.")
+					 (list (format nil "That's not a command, but I admire your confidence.")
 					       (format nil "  Try ~A for a list of commands." (make-short-url-string (plugin-context plug-request) "help"))))
 					(t nil)))))
 
@@ -122,7 +122,7 @@
 		(format nil "📈  ~A opened at $~$ with high of ~A low of ~A, closing at ~A with volume of ~A"
 			(stock-name quote)  (stock-open quote) (stock-high quote) (stock-low quote)
                         (stock-close quote) (stock-volume quote))
-		(format nil "📈  No quotes for symbol: ~A. Perhaps you mistyped?" symbol))))))
+		(format nil "📈  Nothing for ~A. Either it doesn't trade or the market's as confused as you are." symbol))))))
 
 (defplugin toynb (plug-request)
   (case (plugin-action plug-request)
@@ -151,7 +151,7 @@
 	    (if (and countries (listp countries))
 		(loop for (a . b) in countries
 		      :collect (format nil "🌍  [ ~a ][ ~a ]" a b))
-		(format nil "🌍  No match for search term: ~A" country))))))
+		(format nil "🌍  Nothing matches ~A. Geography: clearly not your strong suit." country))))))
 
 (defplugin area (plug-request)
   (case (plugin-action plug-request)
@@ -164,7 +164,7 @@
 	    (if (and area (listp area))
 		(loop for (a . b) in area
 		      :collect (format nil "☎  [ ~A ][ ~A ]" a b))
-		(format nil "☎  No area code found for your search term: ~A" searchterm))))))
+		(format nil "☎  No area code for ~A. Did you dial that with your eyes closed?" searchterm))))))
 
 (defplugin iata (plug-request)
   (case (plugin-action plug-request)
@@ -175,7 +175,7 @@
 	    (if (and airports (listp airports))
 		(loop for (a . b) in airports
 		      :collect (format nil "✈  [ ~A ][ ~A ]" a b))
-		(format nil "✈  No match for your airport: ~A" searchterm))))))
+		(format nil "✈  No airport matches ~A. That's not a place, that's a typo." searchterm))))))
 
 (defplugin ciso (plug-request)
   (case (plugin-action plug-request)

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -954,30 +954,65 @@ Returns :ok, :not-found, or :not-owner."
 ;;; Phrase voting (issue #1)
 ;;; ============================================================
 
+(defun vote-by-offset (channel offset voter)
+  "Vote on the phrase OFFSET positions back in CHANNEL (0 = newest).
+Returns a user-facing status string."
+  (let ((id (db-nth-recent-phrase-id channel offset)))
+    (cond
+      ((null id)
+       (if (zerop offset)
+           "I haven't said anything votable in here yet."
+           (format nil "I haven't said ~D thing~:P back in here." (1+ offset))))
+      (t (case (db-vote-phrase id voter)
+           (:ok
+            (let ((count (db-phrase-vote-count id)))
+              (format nil "🗳  Vote recorded for phrase #~D (~D vote~:P total)." id count)))
+           (:already-voted
+            (format nil "You've already voted for phrase #~D." id))
+           (:not-found
+            (format nil "No phrase #~D found." id)))))))
+
 (defplugin vote (plug-request)
   (case (plugin-action plug-request)
-    (:docstring "Vote for a bot phrase. Usage: !vote <phrase-id>")
+    (:docstring "Vote on a recent bot phrase. Usage: !vote (last) | !vote -N (Nth back) | !vote index")
     (:priority 1.5)
     (:run (let* ((tokens (plugin-token-text-list plug-request))
-                 (id-str (second tokens))
-                 (id (when id-str (parse-integer id-str :junk-allowed t)))
+                 (arg (second tokens))
+                 (channel (plugin-channel-name plug-request))
+                 (conn (plugin-conn plug-request))
                  (voter (prefix-nick (parse-prefix
                                       (message-prefix
-                                       (last-message (plugin-conn plug-request)))))))
-            (cond
-              ((null id) "Usage: !vote <phrase-id>")
-              (t (handler-case
-                     (let ((result (db-vote-phrase id voter)))
-                       (case result
-                         (:ok
-                          (let ((count (db-phrase-vote-count id)))
-                            (format nil "🗳  Vote recorded for phrase #~D (~D vote~:P total)." id count)))
-                         (:already-voted
-                          (format nil "You've already voted for phrase #~D." id))
-                         (:not-found
-                          (format nil "No phrase #~D found." id))))
-                   (error (e)
-                     (format nil "Error voting: ~A" e)))))))))
+                                       (last-message conn))))))
+            (handler-case
+                (cond
+                  ;; !vote index -> private listing of the last 20 phrases
+                  ((and arg (string-equal arg "index"))
+                   (let ((rows (db-recent-phrases channel 20)))
+                     (cond
+                       ((null rows)
+                        "No phrases recorded for this channel yet.")
+                       (t
+                        (qmess conn voter
+                               (format nil "Last ~D phrase~:P in ~A - vote with !vote -N:"
+                                       (length rows) channel))
+                        (loop for row in rows
+                              for offset from 0
+                              for (nil phrase votes) = row
+                              do (qmess conn voter
+                                        (format nil "~3D: [~D vote~:P] ~A"
+                                                (- offset) votes phrase)))
+                        (format nil "Sent you the last ~D phrase~:P in a private message, ~A."
+                                (length rows) voter)))))
+                  ;; !vote or !vote -N -> resolve a relative offset
+                  (t (let ((offset (if arg
+                                       (let ((n (parse-integer arg :junk-allowed t)))
+                                         (and n (abs n)))
+                                       0)))
+                       (if (null offset)
+                           "Usage: !vote | !vote -N | !vote index"
+                           (vote-by-offset channel offset voter)))))
+              (error (e)
+                (format nil "Error voting: ~A" e)))))))
 
 (defplugin top (plug-request)
   (case (plugin-action plug-request)

--- a/util.lisp
+++ b/util.lisp
@@ -211,3 +211,139 @@ a single web-server-name."
     (if utm-index
 	(subseq url 0 utm-index)
 	url)))
+
+;;; ---- Shared web page styling -------------------------------------------
+;;
+;; Every bot-served HTML page shares one cohesive look: a dark "terminal"
+;; theme layered over Pico CSS, with a phosphor-green accent, monospace
+;; headings, a sticky nav linking the pages together, and a footer.
+
+(defparameter +bot-page-css+
+  "
+:root{
+  --accent:#3ddc84; --accent-soft:rgba(61,220,132,.12);
+  --ink:#e6edf3; --muted:#8b98a5; --bg:#0b0e13; --panel:#121821;
+  --border:rgba(255,255,255,.07);
+  --pico-font-family-sans-serif:'IBM Plex Sans',system-ui,sans-serif;
+  --pico-font-family-monospace:'JetBrains Mono',ui-monospace,monospace;
+}
+:root:not([data-theme=light]),[data-theme=dark]{
+  --pico-primary:var(--accent); --pico-primary-hover:#5cead0;
+  --pico-primary-focus:var(--accent-soft);
+  --pico-background-color:var(--bg); --pico-card-background-color:var(--panel);
+  --pico-color:var(--ink); --pico-h1-color:var(--ink);
+  --pico-h2-color:var(--ink); --pico-h3-color:var(--ink);
+  --pico-muted-color:var(--muted);
+}
+body{
+  font-family:var(--pico-font-family-sans-serif); min-height:100vh;
+  background:
+    radial-gradient(900px 500px at 78% -8%,var(--accent-soft),transparent 55%),
+    radial-gradient(700px 400px at 0% 0%,rgba(80,140,255,.06),transparent 50%),
+    var(--bg);
+  background-attachment:fixed;
+}
+.site-head{
+  position:sticky; top:0; z-index:20;
+  background:color-mix(in srgb,var(--bg) 78%,transparent);
+  -webkit-backdrop-filter:blur(10px); backdrop-filter:blur(10px);
+  border-bottom:1px solid var(--border);
+}
+.site-head>.container{
+  display:flex; align-items:center; justify-content:space-between;
+  padding-block:.55rem;
+}
+.brand{
+  font-family:var(--pico-font-family-monospace); font-weight:700;
+  font-size:1.05rem; letter-spacing:.02em; color:var(--accent);
+  text-decoration:none; display:inline-flex; align-items:center; gap:.15rem;
+}
+.cursor{ color:var(--accent); animation:blink 1.1s steps(2,start) infinite; }
+@keyframes blink{ 50%{ opacity:.15; } }
+.site-nav{
+  display:flex; gap:1.2rem; font-family:var(--pico-font-family-monospace);
+  font-size:.86rem;
+}
+.site-nav a{
+  color:var(--muted); text-decoration:none; padding-block:.2rem;
+  border-bottom:1px solid transparent; transition:color .15s,border-color .15s;
+}
+.site-nav a:hover{ color:var(--accent); border-bottom-color:var(--accent); }
+.page-head{ margin-top:2.4rem; margin-bottom:1.4rem; }
+.page-head h1{
+  font-family:var(--pico-font-family-monospace); font-weight:700;
+  font-size:clamp(1.6rem,3vw,2.3rem); letter-spacing:-.01em; margin-bottom:.2rem;
+}
+.page-head .subtitle{ color:var(--muted); margin:0; }
+h2,h3{ font-family:var(--pico-font-family-monospace); letter-spacing:-.01em; }
+.panel{
+  background:var(--panel); border:1px solid var(--border); border-radius:14px;
+  padding:1.1rem 1.3rem 1.3rem; margin-block:1.3rem;
+}
+.panel>:first-child{ margin-top:0; }
+.section-title{
+  display:flex; align-items:center; gap:.55rem; margin-bottom:.9rem;
+  padding-bottom:.6rem; border-bottom:1px solid var(--border);
+}
+table{ margin:0; }
+thead th{
+  font-family:var(--pico-font-family-monospace); font-size:.74rem;
+  text-transform:uppercase; letter-spacing:.08em; color:var(--muted);
+}
+tbody tr{ transition:background .12s; }
+tbody tr:hover{ background:var(--accent-soft); }
+.votes{ font-family:var(--pico-font-family-monospace); color:var(--accent); font-weight:600; }
+code,kbd{
+  font-family:var(--pico-font-family-monospace); background:var(--accent-soft);
+  color:var(--ink); border-radius:6px; padding:.05rem .35rem;
+}
+.empty{ color:var(--muted); font-style:italic; }
+ul.links{ list-style:none; padding:0; }
+ul.links li{ padding:.35rem 0; border-bottom:1px solid var(--border); }
+ul.links li:last-child{ border-bottom:0; }
+dl.help dt{ font-family:var(--pico-font-family-monospace); color:var(--accent); margin-top:.85rem; }
+dl.help dd{ color:var(--ink); margin-left:0; padding-left:1rem; border-left:1px solid var(--border); }
+.site-foot{
+  margin-block:3.5rem 2rem; padding-top:1.1rem;
+  border-top:1px solid var(--border); color:var(--muted);
+}
+")
+
+(defmacro with-bot-page ((&key title subtitle) &body body)
+  "Render a complete, styled HTML page sharing the bot's dark terminal theme.
+TITLE supplies both the document <title> and the page heading.  SUBTITLE,
+when given, is rendered as a lead paragraph.  BODY is spinneret markup for
+the page content (typically one or more (:section :class \"panel\" ...))."
+  (let ((ctx (gensym "PAGE-CTX")))
+    `(let ((,ctx (make-instance 'bot-context
+                                :bot-web-port (acceptor-port (request-acceptor *request*)))))
+       (spinneret:with-html-string
+         (:doctype)
+         (:html :lang "en" :data-theme "dark"
+          (:head
+           (:meta :charset "utf-8")
+           (:meta :name "viewport" :content "width=device-width, initial-scale=1")
+           (:link :rel "preconnect" :href "https://fonts.googleapis.com")
+           (:link :rel "preconnect" :href "https://fonts.gstatic.com" :crossorigin "")
+           (:link :rel "stylesheet"
+                  :href "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@500;700&display=swap")
+           (:link :rel "stylesheet"
+                  :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
+           (:style (:raw +bot-page-css+))
+           (:title ,title))
+          (:body
+           (:header :class "site-head"
+             (:div :class "container"
+               (:a :class "brand" :href (make-short-url-string ,ctx "")
+                   (bot-nick ,ctx) (:span :class "cursor" "_"))
+               (:nav :class "site-nav"
+                 (:a :href (make-short-url-string ,ctx "board") "board")
+                 (:a :href (make-short-url-string ,ctx "phrases") "phrases")
+                 (:a :href (make-short-url-string ,ctx "help") "help"))))
+           (:main :class "container"
+             (:hgroup :class "page-head"
+               (:h1 ,title)
+               ,@(when subtitle `((:p :class "subtitle" ,subtitle))))
+             ,@body)
+           (:footer :class "container site-foot"
+             (:small "served by " (bot-nick ,ctx) (:span :class "cursor" " _")))))))))

--- a/util.lisp
+++ b/util.lisp
@@ -352,9 +352,14 @@ dl.help dd{ color:var(--ink); margin-left:0; padding-left:1rem; border-left:1px 
 TITLE supplies both the document <title> and the page heading.  SUBTITLE,
 when given, is rendered as a lead paragraph.  BODY is spinneret markup for
 the page content (typically one or more (:section :class \"panel\" ...))."
-  (let ((ctx (gensym "PAGE-CTX")))
-    `(let ((,ctx (make-instance 'bot-context
-                                :bot-web-port (acceptor-port (request-acceptor *request*)))))
+  (let ((ctx (gensym "PAGE-CTX"))
+        (csuffix (gensym "CSUFFIX")))
+    `(let* ((,ctx (make-instance 'bot-context
+                                 :bot-web-port (acceptor-port (request-acceptor *request*))))
+            (,csuffix (let ((c (and (boundp 'hunchentoot:*request*) (get-parameter "c"))))
+                        (if (and c (plusp (length c)))
+                            (format nil "?c=~A" (url-encode c))
+                            ""))))
        (spinneret:with-html-string
          (:doctype)
          (:html :lang "en" :data-theme "dark"
@@ -375,8 +380,8 @@ the page content (typically one or more (:section :class \"panel\" ...))."
                (:a :class "brand" :href (make-short-url-string ,ctx "")
                    (bot-nick ,ctx) (:span :class "cursor" "_"))
                (:nav :class "site-nav"
-                 (:a :href (make-short-url-string ,ctx "board") "board")
-                 (:a :href (make-short-url-string ,ctx "phrases") "phrases")
+                 (:a :href (make-short-url-string ,ctx (format nil "board~A" ,csuffix)) "board")
+                 (:a :href (make-short-url-string ,ctx (format nil "phrases~A" ,csuffix)) "phrases")
                  (:a :href (make-short-url-string ,ctx "") "links")
                  (:a :href (make-short-url-string ,ctx "help") "help"))))
            (:main :class "container"

--- a/util.lisp
+++ b/util.lisp
@@ -339,6 +339,7 @@ the page content (typically one or more (:section :class \"panel\" ...))."
                (:nav :class "site-nav"
                  (:a :href (make-short-url-string ,ctx "board") "board")
                  (:a :href (make-short-url-string ,ctx "phrases") "phrases")
+                 (:a :href (make-short-url-string ,ctx "") "links")
                  (:a :href (make-short-url-string ,ctx "help") "help"))))
            (:main :class "container"
              (:hgroup :class "page-head"

--- a/util.lisp
+++ b/util.lisp
@@ -212,6 +212,44 @@ a single web-server-name."
 	(subseq url 0 utm-index)
 	url)))
 
+;;; ---- Personality knobs -------------------------------------------------
+;;
+;; Tunable at runtime (e.g. from the Slynk REPL) to make the bot more or
+;; less chatty and sarcastic without rebuilding.
+
+(defparameter *spontaneous-reply-chance* 0.08
+  "Probability [0.0-1.0] that the bot fires an unprompted Markov reply to a
+message containing no trigger word.  0.0 disables spontaneous chatter.")
+
+(defparameter *snark-chance* 0.15
+  "Probability [0.0-1.0] that the bot tags a Markov reply with a sarcastic
+aside drawn from *SARCASM*.  0.0 disables the snark layer.")
+
+(defparameter *sarcasm*
+  '("But what do I know, I'm just a bot."
+    "Riveting stuff, truly."
+    "I'll alert the media."
+    "Bold of you to assume I care."
+    "Groundbreaking."
+    "Cool story."
+    "Try to contain your excitement."
+    "Sure, let's go with that."
+    "I'm thrilled for you. Genuinely."
+    "Noted, and immediately forgotten."
+    "Fascinating. Next."
+    "You're a regular Oscar Wilde."
+    "Hold the front page."
+    "Be still my beating CPU."
+    "Wow. Just... wow."
+    "Astonishing insight, as always.")
+  "A pool of dry one-liners the bot occasionally appends to its chatter.")
+
+(defun maybe-snarkify (text)
+  "Occasionally append a sarcastic aside to TEXT, governed by *SNARK-CHANCE*."
+  (if (and *sarcasm* (< (random 1.0) *snark-chance*))
+      (format nil "~A  ~A" text (random-elt *sarcasm*))
+      text))
+
 ;;; ---- Shared web page styling -------------------------------------------
 ;;
 ;; Every bot-served HTML page shares one cohesive look: a dark "terminal"

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -30,22 +30,19 @@ degrade to plain HTTP rather than aborting startup."
   "Generate HTML for the Web page listing the Web links in the database."
   (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
          (bothandle (bot-nick context))
-         (channel (bot-irc-channel context)))
-    (spinneret:with-html-string
-      (:html
-       (:head
-        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
-        (:title (format nil "URL index for ~A on ~A" bothandle channel)))
-       (:body
-        (:h2 (format nil "URL index for ~A on ~A" bothandle channel))
-        (:br)
-        (:ul
-         ;; context delimited by web port, so selecting the port here, selects the instance/channel of the bot.
-         (dolist (link (get-urls-and-headlines store (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*)))))
-	   (let ((target (car link))
-		 (link-description (cadr link)))
-             (:li
-              (:a :href target link-description ))))))))))
+         (channel (bot-irc-channel context))
+         (links (get-urls-and-headlines store context)))
+    (with-bot-page (:title (format nil "URL index for ~A on ~A" bothandle channel)
+                    :subtitle "Links shared in the channel, freshest first.")
+      (:section :class "panel"
+        (:h3 :class "section-title" "🔗  Links")
+        (if links
+            (:ul :class "links"
+              (dolist (link links)
+                (let ((target (car link))
+                      (link-description (cadr link)))
+                  (:li (:a :href target link-description)))))
+            (:p :class "empty" "No links saved yet."))))))
 
 (defvar +ass-timestamp-format+ '((:YEAR 4) #\- (:MONTH 2) #\- (:DAY 2)))
 
@@ -104,36 +101,29 @@ or an error message, as appropriate."
   (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
          (bothandle (bot-nick context))
          (channel (bot-irc-channel context))
-         (ctx-id (chain-read-context-id context)))
-    (spinneret:with-html-string
-      (:html
-       (:head
-        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
-        (:title (format nil "Top phrases for ~A on ~A" bothandle channel)))
-       (:body
-        (:h2 (format nil "Top phrases for ~A on ~A" bothandle channel))
-        (:p "Vote for phrases on IRC with " (:code "!vote <id>"))
-        (:br)
-        (let ((rows (handler-case (db-top-phrases-for-web ctx-id 50)
-                      (error (e)
-                        (declare (ignore e))
-                        nil))))
-          (if rows
-              (:table
-               (:thead
-                (:tr (:th "#") (:th "Votes") (:th "Phrase") (:th "Trigger")))
-               (:tbody
-                (dolist (row rows)
-                  (let ((pid (first row))
-                        (trigger (third row))
-                        (phrase (fourth row))
-                        (votes (fifth row)))
-                    (:tr
-                     (:td (format nil "~D" pid))
-                     (:td (format nil "~D" votes))
-                     (:td phrase)
-                     (:td (or trigger "")))))))
-              (:p "No phrases yet."))))))))
+         (ctx-id (chain-read-context-id context))
+         (rows (handler-case (db-top-phrases-for-web ctx-id 50)
+                 (error (e) (declare (ignore e)) nil))))
+    (with-bot-page (:title (format nil "Top phrases for ~A on ~A" bothandle channel)
+                    :subtitle "Vote on IRC with !vote, !vote -N, or !vote index.")
+      (:section :class "panel"
+        (:h3 :class "section-title" "🗳  Top-voted phrases")
+        (if rows
+            (:table
+             (:thead
+              (:tr (:th "#") (:th "Votes") (:th "Phrase") (:th "Trigger")))
+             (:tbody
+              (dolist (row rows)
+                (let ((pid (first row))
+                      (trigger (third row))
+                      (phrase (fourth row))
+                      (votes (fifth row)))
+                  (:tr
+                   (:td (format nil "~D" pid))
+                   (:td (:span :class "votes" (format nil "~D" votes)))
+                   (:td phrase)
+                   (:td (or trigger "")))))))
+            (:p :class "empty" "No phrases have been voted on yet."))))))
 
 (defun phrases-dispatch ()
   "Dispatcher for the top-phrases page."
@@ -150,17 +140,10 @@ channel quotes shown together with their context."
                     (error (e) (declare (ignore e)) nil)))
          (quotes (handler-case (db-recent-quotes-for-web channel 25)
                    (error (e) (declare (ignore e)) nil))))
-    (spinneret:with-html-string
-      (:html
-       (:head
-        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
-        (:title (format nil "Bulletin board for ~A on ~A" bothandle channel)))
-       (:body
-        (:h2 (format nil "Bulletin board for ~A on ~A" bothandle channel))
-        (:p "Vote on phrases in IRC with " (:code "!vote") ", " (:code "!vote -N")
-            ", or " (:code "!vote index") ".  Add quotes with " (:code "!addquote") ".")
-        (:hr)
-        (:h3 "🗳  Top-voted phrases")
+    (with-bot-page (:title (format nil "Bulletin board for ~A on ~A" bothandle channel)
+                    :subtitle "Vote on phrases with !vote, !vote -N, or !vote index. Add quotes with !addquote.")
+      (:section :class "panel"
+        (:h3 :class "section-title" "🗳  Top-voted phrases")
         (if phrases
             (:table
              (:thead
@@ -173,12 +156,12 @@ channel quotes shown together with their context."
                       (votes (fifth row)))
                   (:tr
                    (:td (format nil "~D" pid))
-                   (:td (format nil "~D" votes))
+                   (:td (:span :class "votes" (format nil "~D" votes)))
                    (:td phrase)
                    (:td (or trigger "")))))))
-            (:p "No phrases have been voted on yet."))
-        (:hr)
-        (:h3 "❝  Latest quotes")
+            (:p :class "empty" "No phrases have been voted on yet.")))
+      (:section :class "panel"
+        (:h3 :class "section-title" "❝  Latest quotes")
         (if quotes
             (:table
              (:thead
@@ -194,7 +177,7 @@ channel quotes shown together with their context."
                    (:td added-by)
                    (:td (format nil "~A" (or added-at "")))
                    (:td quote-text))))))
-            (:p "No quotes saved yet.")))))))
+            (:p :class "empty" "No quotes saved yet."))))))
 
 (defun board-dispatch ()
   "Dispatcher for the bulletin board page."
@@ -202,16 +185,11 @@ channel quotes shown together with their context."
 
 (defun html-apology ()
   "Return HTML for a page explaining that a browser has struck out."
-  (spinneret:with-html-string
-    (:html
-     (:head
-      (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
-      (:title "You are in a maze of twisty little redirects, all alike."))
-     (:body
-      (:h1
-       (:p "With apologies")
-       (:p "I don't have that URL...")
-       (:p "Perhaps you mistyped?"))))))
+  (with-bot-page (:title "404 - lost in the redirects"
+                  :subtitle "You are in a maze of twisty little redirects, all alike.")
+    (:section :class "panel"
+      (:p "I don't have that URL...")
+      (:p :class "empty" "Perhaps you mistyped?"))))
 
 (defun help-dispatch ()
   "Dispatcher for the help page served by the bot."

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -139,6 +139,67 @@ or an error message, as appropriate."
   "Dispatcher for the top-phrases page."
   (make-webpage-listing-phrases))
 
+(defun make-webpage-bulletin-board ()
+  "Generate HTML for the bulletin board: top-voted phrases and recent
+channel quotes shown together with their context."
+  (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
+         (bothandle (bot-nick context))
+         (channel (bot-irc-channel context))
+         (ctx-id (chain-read-context-id context))
+         (phrases (handler-case (db-top-phrases-for-web ctx-id 25)
+                    (error (e) (declare (ignore e)) nil)))
+         (quotes (handler-case (db-recent-quotes-for-web channel 25)
+                   (error (e) (declare (ignore e)) nil))))
+    (spinneret:with-html-string
+      (:html
+       (:head
+        (:link :rel "stylesheet" :href "https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css")
+        (:title (format nil "Bulletin board for ~A on ~A" bothandle channel)))
+       (:body
+        (:h2 (format nil "Bulletin board for ~A on ~A" bothandle channel))
+        (:p "Vote on phrases in IRC with " (:code "!vote") ", " (:code "!vote -N")
+            ", or " (:code "!vote index") ".  Add quotes with " (:code "!addquote") ".")
+        (:hr)
+        (:h3 "🗳  Top-voted phrases")
+        (if phrases
+            (:table
+             (:thead
+              (:tr (:th "#") (:th "Votes") (:th "Phrase") (:th "Trigger")))
+             (:tbody
+              (dolist (row phrases)
+                (let ((pid (first row))
+                      (trigger (third row))
+                      (phrase (fourth row))
+                      (votes (fifth row)))
+                  (:tr
+                   (:td (format nil "~D" pid))
+                   (:td (format nil "~D" votes))
+                   (:td phrase)
+                   (:td (or trigger "")))))))
+            (:p "No phrases have been voted on yet."))
+        (:hr)
+        (:h3 "❝  Latest quotes")
+        (if quotes
+            (:table
+             (:thead
+              (:tr (:th "#") (:th "Added by") (:th "When") (:th "Quote")))
+             (:tbody
+              (dolist (row quotes)
+                (let ((qid (first row))
+                      (added-by (second row))
+                      (quote-text (third row))
+                      (added-at (fourth row)))
+                  (:tr
+                   (:td (format nil "~D" qid))
+                   (:td added-by)
+                   (:td (format nil "~A" (or added-at "")))
+                   (:td quote-text))))))
+            (:p "No quotes saved yet.")))))))
+
+(defun board-dispatch ()
+  "Dispatcher for the bulletin board page."
+  (make-webpage-bulletin-board))
+
 (defun html-apology ()
   "Return HTML for a page explaining that a browser has struck out."
   (spinneret:with-html-string
@@ -238,6 +299,7 @@ One acceptor is created and started per connection-spec in *BOT-CONFIG*."
   (glom-on-static-file "/robots.txt" "harlie/robots.txt")
   (glom-on-regex "^/help/?$" 'help-dispatch)
   (glom-on-regex "^/phrases/?$" 'phrases-dispatch)
+  (glom-on-regex "^/board/?$" 'board-dispatch)
   (glom-on-regex "^/source" 'source-dispatch)
   (glom-on-regex "^/hyper(spec)?/?$" 'hyperspec-base-dispatch)
   (glom-on-folder "/HyperSpec/" "HyperSpec/")

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -26,6 +26,14 @@ degrade to plain HTTP rather than aborting startup."
                      cert key)
            nil))))))
 
+(defun request-channel-param ()
+  "Return the IRC channel named in the request's c= parameter, or NIL.
+Several channels can share one connection-spec (hence one web port), so
+the channel-scoped pages (board, phrases) carry the channel explicitly."
+  (when (boundp 'hunchentoot:*request*)
+    (let ((c (get-parameter "c")))
+      (when (and c (plusp (length c))) c))))
+
 (defun make-webpage-listing-urls (store)
   "Generate HTML for the Web page listing the Web links in the database."
   (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
@@ -96,9 +104,11 @@ or an error message, as appropriate."
 	(let ((page (make-webpage-listing-urls *the-url-store*)))
 	  (values (format nil "~A" page))))))
 
-(defun make-webpage-listing-phrases ()
+(defun make-webpage-listing-phrases (&optional channel)
   "Generate HTML for the top-voted bot phrases."
-  (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
+  (let* ((context (make-instance 'bot-context
+                                 :bot-web-port (acceptor-port (request-acceptor *request*))
+                                 :bot-irc-channel channel))
          (bothandle (bot-nick context))
          (channel (bot-irc-channel context))
          (ctx-id (chain-read-context-id context))
@@ -127,12 +137,14 @@ or an error message, as appropriate."
 
 (defun phrases-dispatch ()
   "Dispatcher for the top-phrases page."
-  (make-webpage-listing-phrases))
+  (make-webpage-listing-phrases (request-channel-param)))
 
-(defun make-webpage-bulletin-board ()
+(defun make-webpage-bulletin-board (&optional channel)
   "Generate HTML for the bulletin board: top-voted phrases and recent
 channel quotes shown together with their context."
-  (let* ((context (make-instance 'bot-context :bot-web-port (acceptor-port (request-acceptor *request*))))
+  (let* ((context (make-instance 'bot-context
+                                 :bot-web-port (acceptor-port (request-acceptor *request*))
+                                 :bot-irc-channel channel))
          (bothandle (bot-nick context))
          (channel (bot-irc-channel context))
          (ctx-id (chain-read-context-id context))
@@ -181,7 +193,7 @@ channel quotes shown together with their context."
 
 (defun board-dispatch ()
   "Dispatcher for the bulletin board page."
-  (make-webpage-bulletin-board))
+  (make-webpage-bulletin-board (request-channel-param)))
 
 (defun html-apology ()
   "Return HTML for a page explaining that a browser has struck out."


### PR DESCRIPTION
## Summary

This PR adds a channel bulletin board and a small suite of web-facing
features, unifies all bot-served pages under one cohesive theme, gives
harlie an optional chattier/snarkier personality, and fixes a
wrong-channel bug for installs where several channels share one web port.

## What's included

### Phrase voting (relative offsets)
- Reworks phrase voting to use relative offsets (`!vote`, `!vote -N`,
  `!vote index`) so users can vote on recent utterances without copying
  ids around.

### Bulletin board + web commands
- **`!board`** — a per-channel bulletin board page showing top-voted
  phrases and the latest channel quotes side by side.
- **`!links`** — exposes the existing recorded-links index page (served
  at the site root), which previously had no command.
- Top-phrases page retained and linked from the shared nav.

### Unified web theme
- New shared `with-bot-page` macro + theme in `util.lisp`: a dark
  "terminal" look layered on Pico CSS, phosphor-green accent, monospace
  headings, a sticky nav linking the pages, and a footer.
- Every bot-served page (board, phrases, links index, help reference,
  404/apology) now shares this look instead of bare Pico defaults.

### Bug fix: wrong channel on shared web port
- When several channels share one connection-spec they share one
  hunchentoot acceptor/web port, so a port-only context lookup always
  resolved to whichever channel sorted first.
- `bot-context` now resolves by (web-port + channel) first when both are
  known; `!board` encodes its originating channel as a `?c=` parameter;
  the board/phrases dispatchers and the shared nav honour it. The links
  page stays per-port (the URL store is keyed by port).

## Notes
- Builds cleanly via `ql:quickload :harlie` (SBCL).
- No schema changes required beyond what the existing startup path
  creates.
