### PR TITLE
Add timed multiple-choice polls (!poll) with IRC + web views

### DIFF
--- a/database/add-polls-tables.sql
+++ b/database/add-polls-tables.sql
@@ -1,0 +1,90 @@
+-- add-polls-tables.sql
+-- Migration: add the polls, poll_options and poll_votes tables.
+--
+-- Backs the !poll command: timed, multiple-choice channel polls that
+-- are defined in a private query window, published to a channel, voted
+-- on by channel members (one vote per nick), and auto-closed with a
+-- results announcement when their timer expires.
+--
+-- Polls survive bot restarts because their expiry is stored as a
+-- timestamptz; a periodic sweeper closes and announces any poll whose
+-- expires_at has passed.
+--
+-- Safe to run on an already-migrated database: every step is idempotent.
+--
+-- Run once with:
+--   psql -U <bot_user> -d <bot_db> -f database/add-polls-tables.sql
+--
+-- Author: Glenn Thompson
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.polls (
+    poll_id    serial       PRIMARY KEY,
+    channel    text         NOT NULL,
+    question   text         NOT NULL,
+    creator    text         NOT NULL,
+    created_at timestamptz  DEFAULT now(),
+    expires_at timestamptz  NOT NULL,
+    published  boolean      NOT NULL DEFAULT false,
+    closed     boolean      NOT NULL DEFAULT false,
+    announced  boolean      NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS polls_channel_idx
+    ON public.polls (channel);
+
+CREATE INDEX IF NOT EXISTS polls_sweep_idx
+    ON public.polls (announced, closed, expires_at);
+
+CREATE TABLE IF NOT EXISTS public.poll_options (
+    poll_id     integer NOT NULL REFERENCES public.polls(poll_id) ON DELETE CASCADE,
+    option_num  integer NOT NULL,
+    option_text text    NOT NULL,
+    PRIMARY KEY (poll_id, option_num)
+);
+
+CREATE TABLE IF NOT EXISTS public.poll_votes (
+    poll_id    integer     NOT NULL REFERENCES public.polls(poll_id) ON DELETE CASCADE,
+    voter      text        NOT NULL,
+    option_num integer     NOT NULL,
+    voted_at   timestamptz DEFAULT now(),
+    PRIMARY KEY (poll_id, voter)
+);
+
+CREATE INDEX IF NOT EXISTS poll_votes_poll_idx
+    ON public.poll_votes (poll_id);
+
+-- Transfer ownership to whichever role already owns the rest of the
+-- harlie schema, so the bot user can read/write these tables even when
+-- the migration is run as postgres.  We pick the owner of public.contexts
+-- (guaranteed to exist by this point) rather than the database owner,
+-- matching the approach used by add-phrases-tables.sql.
+DO $$
+DECLARE
+    schema_owner text;
+BEGIN
+    SELECT tableowner INTO schema_owner
+      FROM pg_catalog.pg_tables
+     WHERE schemaname = 'public'
+       AND tablename  = 'contexts';
+
+    IF schema_owner IS NULL THEN
+        RAISE EXCEPTION 'cannot determine harlie schema owner: public.contexts not found';
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.polls OWNER TO %I', schema_owner);
+    EXECUTE format('ALTER TABLE public.poll_options OWNER TO %I', schema_owner);
+    EXECUTE format('ALTER TABLE public.poll_votes OWNER TO %I', schema_owner);
+    EXECUTE format('ALTER SEQUENCE public.polls_poll_id_seq OWNER TO %I', schema_owner);
+END
+$$;
+
+COMMIT;
+
+DO $$
+BEGIN
+    RAISE NOTICE '';
+    RAISE NOTICE 'Polls migration complete.';
+    RAISE NOTICE 'The !poll command is now available.';
+END $$;

--- a/database/bot-schema.sql.template
+++ b/database/bot-schema.sql.template
@@ -653,6 +653,132 @@ ALTER TABLE ONLY public.phrase_votes
 
 
 --
+-- Name: polls; Type: TABLE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE TABLE public.polls (
+    poll_id integer NOT NULL,
+    channel text NOT NULL,
+    question text NOT NULL,
+    creator text NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    expires_at timestamp with time zone NOT NULL,
+    published boolean DEFAULT false NOT NULL,
+    closed boolean DEFAULT false NOT NULL,
+    announced boolean DEFAULT false NOT NULL
+);
+
+
+ALTER TABLE public.polls OWNER TO <bot_runner_uid>;
+
+--
+-- Name: polls_poll_id_seq; Type: SEQUENCE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE SEQUENCE public.polls_poll_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.polls_poll_id_seq OWNER TO <bot_runner_uid>;
+
+--
+-- Name: polls_poll_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER SEQUENCE public.polls_poll_id_seq OWNED BY public.polls.poll_id;
+
+--
+-- Name: poll_options; Type: TABLE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE TABLE public.poll_options (
+    poll_id integer NOT NULL,
+    option_num integer NOT NULL,
+    option_text text NOT NULL
+);
+
+
+ALTER TABLE public.poll_options OWNER TO <bot_runner_uid>;
+
+--
+-- Name: poll_votes; Type: TABLE; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE TABLE public.poll_votes (
+    poll_id integer NOT NULL,
+    voter text NOT NULL,
+    option_num integer NOT NULL,
+    voted_at timestamp with time zone DEFAULT now()
+);
+
+
+ALTER TABLE public.poll_votes OWNER TO <bot_runner_uid>;
+
+--
+-- Name: polls poll_id; Type: DEFAULT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.polls ALTER COLUMN poll_id SET DEFAULT nextval('public.polls_poll_id_seq'::regclass);
+
+--
+-- Name: polls polls_pkey; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.polls
+    ADD CONSTRAINT polls_pkey PRIMARY KEY (poll_id);
+
+--
+-- Name: poll_options poll_options_pkey; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.poll_options
+    ADD CONSTRAINT poll_options_pkey PRIMARY KEY (poll_id, option_num);
+
+--
+-- Name: poll_votes poll_votes_pkey; Type: CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.poll_votes
+    ADD CONSTRAINT poll_votes_pkey PRIMARY KEY (poll_id, voter);
+
+--
+-- Name: polls_channel_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX polls_channel_idx ON public.polls USING btree (channel);
+
+--
+-- Name: polls_sweep_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX polls_sweep_idx ON public.polls USING btree (announced, closed, expires_at);
+
+--
+-- Name: poll_votes_poll_idx; Type: INDEX; Schema: public; Owner: <bot_runner_uid>
+--
+
+CREATE INDEX poll_votes_poll_idx ON public.poll_votes USING btree (poll_id);
+
+--
+-- Name: poll_options poll_options_poll_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.poll_options
+    ADD CONSTRAINT poll_options_poll_id_fkey FOREIGN KEY (poll_id) REFERENCES public.polls(poll_id) ON DELETE CASCADE;
+
+--
+-- Name: poll_votes poll_votes_poll_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: <bot_runner_uid>
+--
+
+ALTER TABLE ONLY public.poll_votes
+    ADD CONSTRAINT poll_votes_poll_id_fkey FOREIGN KEY (poll_id) REFERENCES public.polls(poll_id) ON DELETE CASCADE;
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/harlie.asd
+++ b/harlie.asd
@@ -63,6 +63,7 @@
 	       (:file "irc-client")
 	       (:file "memo")
 	       (:file "phrases")
+	       (:file "polls")
 
 	       (:file "constants")
 	       (:file "chainer")

--- a/harlie.lisp
+++ b/harlie.lisp
@@ -23,12 +23,14 @@
   (sleep 3)
   (start-threaded-irc-client-instances :go? t)
   (start-cron)
-  (add-canonical-crons)) ;; don't start slynk here. it doesn't work.
+  (add-canonical-crons)
+  (start-poll-sweeper)) ;; don't start slynk here. it doesn't work.
 
 
 (defun kill-bot ()
   "Disconnect from the IRC server, clean up persistent data, shut down the Web servers."
   (stop-threaded-irc-client-instances)
+  (stop-poll-sweeper)
   (setf *users* nil)
   (setf *random-state* nil)  
   (stop-web-servers)

--- a/init-first-run.lisp
+++ b/init-first-run.lisp
@@ -64,6 +64,28 @@ the table ownership, and excecute the schema."
   (with-connection (db-credentials *bot-config*)
     (execute-file sqlfile)))
 
+(defparameter *startup-migrations*
+  (list "add-polls-tables.sql")
+  "Idempotent SQL migrations under the database directory that are applied
+on every startup.  This lets schema changes ship with the code: a rebuild
+and restart brings an existing database up to date with no manual psql
+step.  Each listed migration MUST be safe to run repeatedly (it should use
+CREATE TABLE IF NOT EXISTS and similar guards).")
+
+(defun apply-startup-migrations ()
+  "Apply each migration in *STARTUP-MIGRATIONS* to the live database.
+Errors are logged rather than signalled so a single bad migration cannot
+stop the bot from starting."
+  (dolist (name *startup-migrations*)
+    (let ((file (merge-pathnames *here-db* name)))
+      (handler-case
+          (progn
+            (with-connection (db-credentials *bot-config*)
+              (execute-file file))
+            (log:info "~&[MIGRATION] Applied ~A" name))
+        (error (e)
+          (log:warn "~&[MIGRATION] Failed to apply ~A: ~A" name e))))))
+
 (defun initialize-startup-maybe (&key (go? nil))
   (let* ((db-template (merge-pathnames *here-db* "bot-schema.sql.template"))
          (db-schema   (merge-pathnames *here-db* "bot-schema.sql")))
@@ -77,6 +99,9 @@ the table ownership, and excecute the schema."
         (log:info "Creating tables for the various required users...")
         (uiop:copy-file db-template db-schema)
         (make-base-tables db-schema)))
+    ;; Apply idempotent migrations on every startup, so a rebuild and
+    ;; restart brings the database up to date with no manual psql step.
+    (apply-startup-migrations)
     ;; Sync contexts table from config on every startup.
     (when go?
       (load-contexts))))

--- a/plugins.lisp
+++ b/plugins.lisp
@@ -1076,6 +1076,167 @@ Returns a user-facing status string."
                    (error (e)
                      (format nil "Error: ~A" e)))))))))
 
+;;; ============================================================
+;;; Timed polls (!poll)
+;;; ============================================================
+;;
+;; Polls are defined in a private query window, published to a channel,
+;; and voted on by channel members (one vote per nick).  Each poll has a
+;; timer; the sweeper in polls.lisp closes it and announces the results
+;; when it expires.
+
+(defun poll-sender-nick (conn)
+  "Return the nick of whoever sent the message currently being handled."
+  (prefix-nick (parse-prefix (message-prefix (last-message conn)))))
+
+(defun poll-cmd-new (tokens creator)
+  "Handle '!poll new #channel <duration> \"question\" choice...'.
+TOKENS is the full token list; CREATOR is the requesting nick."
+  (let* ((channel-arg  (third tokens))
+         (duration-str (fourth tokens))
+         (rest-string  (format nil "~{~A~^ ~}" (nthcdr 4 tokens)))
+         (parts        (split-quoted rest-string))
+         (question     (first parts))
+         (choices      (rest parts)))
+    (cond
+      ((or (null channel-arg) (null duration-str))
+       "Usage: !poll new #channel <duration> \"question\" choice1 choice2 [choice3] [choice4]")
+      ((null (parse-duration duration-str))
+       (format nil "Invalid duration '~A'. Use e.g. 30m, 2h, 1d." duration-str))
+      ((null question)
+       "Give your poll a question in quotes, e.g. \"Best editor?\"")
+      ((< (length choices) 2)
+       "A poll needs at least 2 choices.")
+      ((> (length choices) 4)
+       "A poll can have at most 4 choices.")
+      (t (let* ((channel (if (or (str:starts-with-p "#" channel-arg)
+                                 (str:starts-with-p "&" channel-arg))
+                             channel-arg
+                             (format nil "#~A" channel-arg)))
+                (seconds (parse-duration duration-str))
+                (id (db-create-poll channel question creator seconds choices)))
+           (format nil "Created poll #~D for ~A (closes in ~A). Review it, then publish with: !poll publish ~D"
+                   id channel (format-duration seconds) id))))))
+
+(defun poll-cmd-publish (id-str creator conn)
+  "Publish poll ID-STR to its channel.  Only the creator may publish."
+  (let ((id (and id-str (parse-integer id-str :junk-allowed t))))
+    (cond
+      ((null id) "Usage: !poll publish <id>")
+      (t (let ((poll (db-get-poll id)))
+           (cond
+             ((null poll) (format nil "No poll #~D found." id))
+             ((not (string-equal (fourth poll) creator))
+              (format nil "Poll #~D isn't yours to publish." id))
+             ((sixth poll)
+              (format nil "Poll #~D is already published." id))
+             ((eighth poll)
+              (format nil "Poll #~D has already closed." id))
+             (t (let ((channel (second poll))
+                      (lines   (format-poll-announcement id)))
+                  (db-publish-poll id)
+                  (dolist (line lines)
+                    (qmess conn channel (format nil "poll:: ~A" line)))
+                  (format nil "Published poll #~D to ~A." id channel)))))))))
+
+(defun poll-cmd-vote (id-str n-str voter)
+  "Record VOTER's choice of option N-STR in poll ID-STR."
+  (let ((id (and id-str (parse-integer id-str :junk-allowed t)))
+        (n  (and n-str  (parse-integer n-str  :junk-allowed t))))
+    (cond
+      ((or (null id) (null n)) "Usage: !poll vote <id> <number>")
+      (t (case (db-vote-poll id voter n)
+           (:ok
+            (let ((text (second (assoc n (db-poll-options id)))))
+              (format nil "🗳  Vote recorded for \"~A\" (poll #~D)." text id)))
+           (:already-voted (format nil "You've already voted in poll #~D." id))
+           (:not-found     (format nil "No poll #~D found." id))
+           (:not-open      (format nil "Poll #~D isn't open for voting." id))
+           (:invalid-option (format nil "Poll #~D has no option ~D." id n)))))))
+
+(defun poll-cmd-results (id-str)
+  "Return the current tally for poll ID-STR as a list of lines."
+  (let ((id (and id-str (parse-integer id-str :junk-allowed t))))
+    (cond
+      ((null id) "Usage: !poll results <id>")
+      (t (let ((poll (db-get-poll id)))
+           (if (null poll)
+               (format nil "No poll #~D found." id)
+               (format-poll-results id :closed (or (seventh poll) (eighth poll)))))))))
+
+(defun poll-cmd-close (id-str closer conn)
+  "Close poll ID-STR early and post its results.  Only the creator may close."
+  (let ((id (and id-str (parse-integer id-str :junk-allowed t))))
+    (cond
+      ((null id) "Usage: !poll close <id>")
+      (t (let ((poll (db-get-poll id)))
+           (cond
+             ((null poll) (format nil "No poll #~D found." id))
+             ((not (string-equal (fourth poll) closer))
+              (format nil "Poll #~D isn't yours to close." id))
+             ((eighth poll) (format nil "Poll #~D is already closed." id))
+             (t (let ((channel (second poll)))
+                  (db-mark-announced id)
+                  (dolist (line (format-poll-results id :closed t))
+                    (qmess conn channel (format nil "poll:: ~A" line)))
+                  (format nil "Closed poll #~D and posted results to ~A." id channel)))))))))
+
+(defun poll-cmd-list (pm-p channel-name creator)
+  "List polls: the requester's own when in a query, open ones when in a channel."
+  (if pm-p
+      (let ((rows (db-polls-by-creator creator)))
+        (if (null rows)
+            "You haven't created any polls yet."
+            (cons "Your recent polls:"
+                  (loop for (id channel question published closed) in rows
+                        collect (format nil "  #~D [~A] ~A - ~A"
+                                        id channel
+                                        (cond (closed "closed")
+                                              (published "open")
+                                              (t "draft"))
+                                        question)))))
+      (let ((rows (db-open-polls channel-name)))
+        (if (null rows)
+            "No open polls in this channel."
+            (cons "Open polls (vote with !poll vote <id> <n>):"
+                  (loop for (id question) in rows
+                        collect (format nil "  #~D ~A" id question)))))))
+
+(defplugin poll (plug-request)
+  (case (plugin-action plug-request)
+    (:docstring "Run a timed multiple-choice poll. Define it in a query window, publish to a channel, members vote. Usage (query window): !poll new #channel <duration> \"question\" choice1 choice2 [c3] [c4] | !poll publish <id> | !poll close <id>. In channel: !poll vote <id> <n> | !poll results <id> | !poll list")
+    (:priority 1.5)
+    (:run
+     (handler-case
+         (let* ((tokens       (plugin-token-text-list plug-request))
+                (sub          (and (second tokens) (string-downcase (second tokens))))
+                (conn         (plugin-conn plug-request))
+                (channel-name (plugin-channel-name plug-request))
+                (pm-p         (string-equal channel-name (connection-nick conn)))
+                (sender       (poll-sender-nick conn)))
+           (cond
+             ((null sub)
+              "Usage: !poll new #channel <duration> \"question\" choice1 choice2 ... | publish <id> | vote <id> <n> | results <id> | close <id> | list")
+             ((string= sub "new")
+              (if pm-p
+                  (poll-cmd-new tokens sender)
+                  "Define polls in a query window, please: /msg me !poll new #channel 30m \"question\" choice1 choice2"))
+             ((string= sub "publish")
+              (if pm-p
+                  (poll-cmd-publish (third tokens) sender conn)
+                  "Publish polls from a query window: /msg me !poll publish <id>"))
+             ((string= sub "vote")
+              (poll-cmd-vote (third tokens) (fourth tokens) sender))
+             ((string= sub "results")
+              (poll-cmd-results (third tokens)))
+             ((string= sub "close")
+              (poll-cmd-close (third tokens) sender conn))
+             ((string= sub "list")
+              (poll-cmd-list pm-p channel-name sender))
+             (t (format nil "Unknown subcommand '~A'. Try: new, publish, vote, results, close, list" sub))))
+       (error (e)
+         (format nil "Error: ~A" e))))))
+
 ;;; !eval removed — "this plugin is too dangerous to live" -Fade
 
 ;; ===[ hyperspace motivator follows. ]===

--- a/polls.lisp
+++ b/polls.lisp
@@ -182,6 +182,20 @@ polls created by CREATOR."
             limit)
            :rows)))
 
+(defun db-polls-for-web (channel &optional (limit 25))
+  "Return recent published polls for CHANNEL for the web view, newest first.
+Each row is (poll-id question creator created-at expires-at closed expired)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'poll-id 'question 'creator 'created-at 'expires-at 'closed
+                      (:raw "(expires_at <= now()) AS expired")
+              :from 'polls
+              :where (:and (:= 'channel channel) 'published))
+             (:desc 'poll-id))
+            limit)
+           :rows)))
+
 ;;; ---- Formatting ---------------------------------------------------------
 
 (defun poll-bar (votes maxv &optional (width 10))
@@ -208,6 +222,16 @@ polls created by CREATOR."
     (if (plusp secs)
         (format nil "in ~A" (format-duration secs))
         "soon")))
+
+(defun format-poll-timestamp (timestamp)
+  "Format TIMESTAMP (a local-time timestamp) as a compact
+\"YYYY-MM-DD HH:MM\" string, or \"unknown\" when it is missing."
+  (if timestamp
+      (local-time:format-timestring
+       nil timestamp
+       :format '((:year 4) #\- (:month 2) #\- (:day 2) #\Space
+                 (:hour 2) #\: (:min 2)))
+      "unknown"))
 
 (defparameter *poll-options-line-max* 400
   "Maximum characters of an options-line's content before it is split across

--- a/polls.lisp
+++ b/polls.lisp
@@ -209,9 +209,38 @@ polls created by CREATOR."
         (format nil "in ~A" (format-duration secs))
         "soon")))
 
+(defparameter *poll-options-line-max* 400
+  "Maximum characters of an options-line's content before it is split across
+multiple PRIVMSGs.  Kept well under IRC's ~512-byte line limit to leave room
+for the channel target and the \"poll:: \" prefix the publisher prepends.")
+
+(defun pack-poll-options (options &key (max-width *poll-options-line-max*))
+  "Format OPTIONS (a list of (num text)) as \"N) text\" entries packed,
+greedily, into as few indented lines as possible without exceeding MAX-WIDTH
+characters per line.  Normally everything fits on one line; only genuinely
+long option labels spill onto further lines.  Returns a list of strings."
+  (let ((entries (loop for (num text) in options
+                       collect (format nil "~D) ~A" num text)))
+        (lines '())
+        (current nil))
+    (dolist (entry entries)
+      (let ((candidate (if current (format nil "~A   ~A" current entry) entry)))
+        (if (and current (> (length candidate) max-width))
+            (progn (push current lines)
+                   (setf current entry))
+            (setf current candidate))))
+    (when current (push current lines))
+    (mapcar (lambda (line) (format nil "  ~A" line)) (nreverse lines))))
+
 (defun format-poll-announcement (poll-id)
-  "Build the multi-line channel announcement published for POLL-ID.
-Returns a list of strings, or NIL if the poll is missing."
+  "Build the channel announcement published for POLL-ID as a compact layout:
+a header, the options (normally a single line), and a vote / closes line.
+Returns a list of strings, or NIL if the poll is missing.
+
+IRC has no multi-line message, so each element is sent as its own PRIVMSG;
+keeping the options together on one line lets a multi-option poll be read at
+a glance instead of scattered across several messages.  PACK-POLL-OPTIONS
+splits the options onto additional lines should they exceed a safe length."
   (let ((poll (db-get-poll poll-id))
         (options (db-poll-options poll-id)))
     (when poll
@@ -220,10 +249,9 @@ Returns a list of strings, or NIL if the poll is missing."
         (declare (ignore channel creator published closed announced))
         (append
          (list (format nil "📊  Poll #~D: ~A" pid question))
-         (loop for (num text) in options
-               collect (format nil "  ~D) ~A" num text))
-         (list (format nil "Vote with: !poll vote ~D <number>  (closes ~A)"
-                       pid (format-poll-deadline expires-at))))))))
+         (pack-poll-options options)
+         (list (format nil "  Vote: !poll vote ~D <n>  ·  closes ~A"
+                        pid (format-poll-deadline expires-at))))))))
 
 (defun format-poll-results (poll-id &key closed)
   "Build a multi-line results report for POLL-ID.  When CLOSED is true the

--- a/polls.lisp
+++ b/polls.lisp
@@ -1,0 +1,288 @@
+;;;; polls.lisp - Timed, multiple-choice channel polls
+;;
+;; A poll is defined privately (in a query window), published to a
+;; channel, and voted on by channel members - one vote per nick.  Each
+;; poll carries an expiry; a periodic sweeper closes any poll whose timer
+;; has elapsed and announces the results in its channel.  Because the
+;; expiry lives in the database rather than in a sleeping thread, polls
+;; survive bot restarts.
+;;
+;; See database/add-polls-tables.sql for the schema and the !poll plugin
+;; in plugins.lisp for the user-facing command surface.
+
+(in-package #:harlie)
+
+;;; ---- Argument parsing ---------------------------------------------------
+
+(defun split-quoted (string)
+  "Split STRING on whitespace, treating double-quoted spans as a single
+token.  Surrounding double quotes are removed.  Empty tokens are dropped."
+  (let ((tokens '())
+        (current (make-string-output-stream))
+        (in-quote nil)
+        (have-token nil))
+    (flet ((flush ()
+             (when have-token
+               (push (get-output-stream-string current) tokens)
+               (setf have-token nil))))
+      (loop for ch across string do
+        (cond
+          ((char= ch #\")
+           (setf in-quote (not in-quote)
+                 have-token t))
+          ((and (not in-quote) (member ch '(#\Space #\Tab)))
+           (flush))
+          (t
+           (write-char ch current)
+           (setf have-token t))))
+      (flush))
+    (remove "" (nreverse tokens) :test #'string=)))
+
+;;; ---- Database operations ------------------------------------------------
+
+(defun db-create-poll (channel question creator seconds options)
+  "Create a poll in CHANNEL with QUESTION and OPTIONS (a list of strings),
+expiring SECONDS from now.  Returns the new poll_id."
+  (with-connection (db-credentials *bot-config*)
+    (query (:insert-into 'polls :set
+            'channel    channel
+            'question   question
+            'creator    creator
+            'expires-at (:raw (format nil "now() + interval '~D seconds'" seconds)))
+           :none)
+    (let ((poll-id (query (:select (:raw "currval('polls_poll_id_seq')")) :single)))
+      (loop for opt in options
+            for n from 1
+            do (query (:insert-into 'poll-options :set
+                       'poll-id     poll-id
+                       'option-num  n
+                       'option-text opt)
+                      :none))
+      poll-id)))
+
+(defun db-get-poll (poll-id)
+  "Return (poll-id channel question creator expires-at published closed
+announced) for POLL-ID, or NIL if it does not exist."
+  (with-connection (db-credentials *bot-config*)
+    (first
+     (query (:select 'poll-id 'channel 'question 'creator 'expires-at
+                     'published 'closed 'announced
+             :from 'polls :where (:= 'poll-id poll-id))
+            :rows))))
+
+(defun db-poll-options (poll-id)
+  "Return the options for POLL-ID as a list of (option-num option-text)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:order-by
+            (:select 'option-num 'option-text :from 'poll-options
+             :where (:= 'poll-id poll-id))
+            'option-num)
+           :rows)))
+
+(defun db-poll-results (poll-id)
+  "Return a list of (option-num option-text votes) for POLL-ID, ordered by
+option-num."
+  (with-connection (db-credentials *bot-config*)
+    (query (:order-by
+            (:select 'o.option-num 'o.option-text
+                     (:raw "COALESCE(v.votes, 0) AS votes")
+             :from (:as 'poll-options 'o)
+             :left-join (:as (:select 'option-num (:as (:count '*) 'votes)
+                              :from 'poll-votes
+                              :where (:= 'poll-id poll-id)
+                              :group-by 'option-num)
+                             'v)
+             :on (:= 'o.option-num 'v.option-num)
+             :where (:= 'o.poll-id poll-id))
+            'o.option-num)
+           :rows)))
+
+(defun db-publish-poll (poll-id)
+  "Mark POLL-ID as published."
+  (with-connection (db-credentials *bot-config*)
+    (query (:update 'polls :set 'published t :where (:= 'poll-id poll-id))
+           :none)))
+
+(defun db-vote-poll (poll-id voter option-num)
+  "Record VOTER's choice of OPTION-NUM in POLL-ID.
+Returns :ok, :already-voted, :not-found, :not-open, or :invalid-option."
+  (with-connection (db-credentials *bot-config*)
+    (let ((poll (query (:select 'published 'closed
+                                (:raw "(expires_at <= now()) AS expired")
+                        :from 'polls :where (:= 'poll-id poll-id))
+                       :row)))
+      (if (null poll)
+          :not-found
+          (destructuring-bind (published closed expired) poll
+            (cond
+              ((or (not published) closed expired) :not-open)
+              ((null (query (:select 'option-num :from 'poll-options
+                             :where (:and (:= 'poll-id poll-id)
+                                          (:= 'option-num option-num)))
+                            :single))
+               :invalid-option)
+              (t (handler-case
+                     (progn
+                       (query (:insert-into 'poll-votes :set
+                               'poll-id    poll-id
+                               'voter      voter
+                               'option-num option-num)
+                              :none)
+                       :ok)
+                   ;; unique violation (PG 23505) means already voted
+                   (database-error (e)
+                     (if (string= "23505" (cl-postgres::database-error-code e))
+                         :already-voted
+                         (error e)))))))))))
+
+(defun db-close-poll (poll-id)
+  "Mark POLL-ID closed (no further votes accepted)."
+  (with-connection (db-credentials *bot-config*)
+    (query (:update 'polls :set 'closed t :where (:= 'poll-id poll-id))
+           :none)))
+
+(defun db-mark-announced (poll-id)
+  "Mark POLL-ID as closed and its results announced."
+  (with-connection (db-credentials *bot-config*)
+    (query (:update 'polls :set 'closed t 'announced t
+            :where (:= 'poll-id poll-id))
+           :none)))
+
+(defun db-pending-poll-announcements ()
+  "Return the poll-ids of published polls that have expired or been closed
+but not yet announced."
+  (with-connection (db-credentials *bot-config*)
+    (query (:select 'poll-id :from 'polls
+            :where (:and 'published
+                         (:not 'announced)
+                         (:or 'closed (:raw "expires_at <= now()"))))
+           :column)))
+
+(defun db-open-polls (channel)
+  "Return (poll-id question) for published, still-open polls in CHANNEL."
+  (with-connection (db-credentials *bot-config*)
+    (query (:order-by
+            (:select 'poll-id 'question :from 'polls
+             :where (:and (:= 'channel channel)
+                          'published
+                          (:not 'closed)
+                          (:raw "expires_at > now()")))
+            'poll-id)
+           :rows)))
+
+(defun db-polls-by-creator (creator &optional (limit 10))
+  "Return (poll-id channel question published closed) for the most recent
+polls created by CREATOR."
+  (with-connection (db-credentials *bot-config*)
+    (query (:limit
+            (:order-by
+             (:select 'poll-id 'channel 'question 'published 'closed
+              :from 'polls :where (:= 'creator creator))
+             (:desc 'poll-id))
+            limit)
+           :rows)))
+
+;;; ---- Formatting ---------------------------------------------------------
+
+(defun poll-bar (votes maxv &optional (width 10))
+  "Return a proportional bar of block characters for VOTES relative to MAXV."
+  (if (or (zerop maxv) (zerop votes))
+      ""
+      (make-string (max 1 (round (* width (/ votes maxv))))
+                   :initial-element #\FULL_BLOCK)))
+
+(defun poll-winner (results)
+  "Return a human-readable string naming the winning option(s) in RESULTS
+\(a list of (option-num option-text votes)), noting ties."
+  (let ((maxv (reduce #'max results :key #'third :initial-value 0)))
+    (if (zerop maxv)
+        "no votes cast"
+        (let ((winners (remove maxv results :key #'third :test-not #'=)))
+          (format nil "~{~A~^, ~}~:[~; (tie)~]"
+                  (mapcar #'second winners)
+                  (> (length winners) 1))))))
+
+(defun format-poll-deadline (expires-at)
+  "Describe how long until EXPIRES-AT (a local-time timestamp)."
+  (let ((secs (- (timestamp-to-universal expires-at) (get-universal-time))))
+    (if (plusp secs)
+        (format nil "in ~A" (format-duration secs))
+        "soon")))
+
+(defun format-poll-announcement (poll-id)
+  "Build the multi-line channel announcement published for POLL-ID.
+Returns a list of strings, or NIL if the poll is missing."
+  (let ((poll (db-get-poll poll-id))
+        (options (db-poll-options poll-id)))
+    (when poll
+      (destructuring-bind (pid channel question creator expires-at
+                           published closed announced) poll
+        (declare (ignore channel creator published closed announced))
+        (append
+         (list (format nil "📊  Poll #~D: ~A" pid question))
+         (loop for (num text) in options
+               collect (format nil "  ~D) ~A" num text))
+         (list (format nil "Vote with: !poll vote ~D <number>  (closes ~A)"
+                       pid (format-poll-deadline expires-at))))))))
+
+(defun format-poll-results (poll-id &key closed)
+  "Build a multi-line results report for POLL-ID.  When CLOSED is true the
+report is framed as a final tally and names the winner.  Returns a list of
+strings, or NIL if the poll is missing."
+  (let ((poll (db-get-poll poll-id))
+        (results (db-poll-results poll-id)))
+    (when poll
+      (destructuring-bind (pid channel question creator expires-at
+                           published closed-flag announced) poll
+        (declare (ignore channel creator expires-at published closed-flag announced))
+        (let* ((total (reduce #'+ results :key #'third :initial-value 0))
+               (maxv  (reduce #'max results :key #'third :initial-value 0)))
+          (append
+           (list (format nil "~A  Poll #~D: ~A (~D vote~:P)"
+                         (if closed "⏱" "📊") pid question total))
+           (loop for (num text votes) in results
+                 collect (format nil "  ~D) ~A  ~A ~D"
+                                 num text (poll-bar votes maxv) votes))
+           (when closed
+             (list (format nil "Winner: ~A" (poll-winner results))))))))))
+
+;;; ---- Expiry sweeper -----------------------------------------------------
+
+(defvar *poll-sweeper-task* nil
+  "The periodic task that closes and announces expired polls.")
+
+(defparameter *poll-sweep-interval* 30
+  "Seconds between sweeps for expired polls.")
+
+(defun sweep-expired-polls ()
+  "Close and announce any published poll that has expired or been closed
+but not yet announced.  Safe to call repeatedly; errors are logged, not
+signalled, so one bad poll cannot stall the sweeper."
+  (handler-case
+      (dolist (poll-id (db-pending-poll-announcements))
+        (handler-case
+            (let ((poll (db-get-poll poll-id)))
+              (when poll
+                (let ((channel (second poll)))
+                  ;; Mark first so a send failure cannot cause repeated spam.
+                  (db-mark-announced poll-id)
+                  (dolist (line (format-poll-results poll-id :closed t))
+                    (say (format nil "poll:: ~A" line) :channel channel)))))
+          (error (e)
+            (log:warn "~&[POLL] Error announcing poll #~D: ~A" poll-id e))))
+    (error (e)
+      (log:warn "~&[POLL] Sweeper error: ~A" e))))
+
+(defun start-poll-sweeper ()
+  "Start the periodic poll-expiry sweeper unless it is already running."
+  (unless *poll-sweeper-task*
+    (setf *poll-sweeper-task*
+          (make-task #'sweep-expired-polls *poll-sweep-interval* "poll-sweeper"))
+    (log:info "~&[POLL] Started poll-expiry sweeper (every ~Ds)."
+              *poll-sweep-interval*)))
+
+(defun stop-poll-sweeper ()
+  "Stop the poll-expiry sweeper if it is running."
+  (when *poll-sweeper-task*
+    (stop-task *poll-sweeper-task*)
+    (setf *poll-sweeper-task* nil)))

--- a/util.lisp
+++ b/util.lisp
@@ -221,7 +221,7 @@ a single web-server-name."
   "Probability [0.0-1.0] that the bot fires an unprompted Markov reply to a
 message containing no trigger word.  0.0 disables spontaneous chatter.")
 
-(defparameter *snark-chance* 0.15
+(defparameter *snark-chance* 0.10
   "Probability [0.0-1.0] that the bot tags a Markov reply with a sarcastic
 aside drawn from *SARCASM*.  0.0 disables the snark layer.")
 

--- a/util.lisp
+++ b/util.lisp
@@ -331,6 +331,7 @@ thead th{
 tbody tr{ transition:background .12s; }
 tbody tr:hover{ background:var(--accent-soft); }
 .votes{ font-family:var(--pico-font-family-monospace); color:var(--accent); font-weight:600; }
+.poll-bar{ font-family:var(--pico-font-family-monospace); color:var(--accent); letter-spacing:-.04em; }
 code,kbd{
   font-family:var(--pico-font-family-monospace); background:var(--accent-soft);
   color:var(--ink); border-radius:6px; padding:.05rem .35rem;
@@ -382,6 +383,7 @@ the page content (typically one or more (:section :class \"panel\" ...))."
                (:nav :class "site-nav"
                  (:a :href (make-short-url-string ,ctx (format nil "board~A" ,csuffix)) "board")
                  (:a :href (make-short-url-string ,ctx (format nil "phrases~A" ,csuffix)) "phrases")
+                 (:a :href (make-short-url-string ,ctx (format nil "polls~A" ,csuffix)) "polls")
                  (:a :href (make-short-url-string ,ctx "") "links")
                  (:a :href (make-short-url-string ,ctx "help") "help"))))
            (:main :class "container"

--- a/web-server.lisp
+++ b/web-server.lisp
@@ -193,6 +193,58 @@ channel quotes shown together with their context."
   "Dispatcher for the bulletin board page."
   (make-webpage-bulletin-board (request-channel-param)))
 
+(defun make-webpage-listing-polls (&optional channel)
+  "Generate HTML listing recent published polls for CHANNEL with their live
+results: a panel per poll showing the question, status, and per-option vote
+counts with a proportional bar."
+  (let* ((context (make-instance 'bot-context
+                                 :bot-web-port (acceptor-port (request-acceptor *request*))
+                                 :bot-irc-channel channel))
+         (bothandle (bot-nick context))
+         (channel (bot-irc-channel context))
+         (polls (handler-case (db-polls-for-web channel 25)
+                  (error (e) (declare (ignore e)) nil))))
+    (with-bot-page (:title (format nil "Polls for ~A on ~A" bothandle channel)
+                    :subtitle "Vote on IRC with !poll vote <id> <n>. Create one with !poll new in a query window.")
+      (if polls
+          (dolist (poll polls)
+            (destructuring-bind (pid question creator created-at expires-at closed expired) poll
+              (let* ((results (handler-case (db-poll-results pid)
+                                (error (e) (declare (ignore e)) nil)))
+                     (total (reduce #'+ results :key #'third :initial-value 0))
+                     (maxv  (reduce #'max results :key #'third :initial-value 0))
+                     (open-p (not (or closed expired)))
+                     (created (format-poll-timestamp created-at)))
+                (:section :class "panel"
+                  (:h3 :class "section-title"
+                       (format nil "📊  #~D: ~A" pid question))
+                  (:p :class "subtitle"
+                      (if open-p
+                          (format nil "open · closes ~A · ~D vote~:P · by ~A · created ~A"
+                                  (format-poll-deadline expires-at) total creator created)
+                          (format nil "closed · ~D vote~:P · winner: ~A · by ~A · created ~A"
+                                  total (poll-winner results) creator created)))
+                  (if results
+                      (:table
+                       (:thead
+                        (:tr (:th "#") (:th "Option") (:th "Votes") (:th "")))
+                       (:tbody
+                        (dolist (r results)
+                          (destructuring-bind (onum otext ovotes) r
+                            (:tr
+                             (:td (format nil "~D" onum))
+                             (:td otext)
+                             (:td (:span :class "votes" (format nil "~D" ovotes)))
+                             (:td (:span :class "poll-bar" (poll-bar ovotes maxv 20))))))))
+                      (:p :class "empty" "No options."))))))
+          (:section :class "panel"
+            (:h3 :class "section-title" "📊  Polls")
+            (:p :class "empty" "No polls have been published yet."))))))
+
+(defun polls-dispatch ()
+  "Dispatcher for the polls page."
+  (make-webpage-listing-polls (request-channel-param)))
+
 (defun html-apology ()
   "Return HTML for a page explaining that a browser has struck out."
   (with-bot-page (:title "404 - lost in the redirects"
@@ -288,6 +340,7 @@ One acceptor is created and started per connection-spec in *BOT-CONFIG*."
   (glom-on-regex "^/help/?$" 'help-dispatch)
   (glom-on-regex "^/phrases/?$" 'phrases-dispatch)
   (glom-on-regex "^/board/?$" 'board-dispatch)
+  (glom-on-regex "^/polls/?$" 'polls-dispatch)
   (glom-on-regex "^/source" 'source-dispatch)
   (glom-on-regex "^/hyper(spec)?/?$" 'hyperspec-base-dispatch)
   (glom-on-folder "/HyperSpec/" "HyperSpec/")


### PR DESCRIPTION
## Summary

Adds **timed, multiple-choice channel polls** to the bot, end to end: an IRC command surface, persistent storage, an auto-closing sweeper, and a web page showing live results.

A poll is defined privately in a query window, published to a channel, and voted on by channel members (one vote per nick). Each poll carries an expiry stored in the database, so polls survive bot restarts; a periodic sweeper closes any expired poll and announces its results.

## IRC commands (`!poll`)

- `!poll new #channel <duration> "question" choice1 choice2 [c3] [c4]` — define a poll (query window only)
- `!poll publish <id>` — publish a defined poll to its channel
- `!poll vote <id> <n>` — cast a vote (one per nick)
- `!poll results <id>` — show current tally
- `!poll close <id>` — close early
- `!poll list` — list polls

Publish output uses a compact layout: a header, the options packed onto a single line for at-a-glance reading, and a vote/closes line. Because IRC has no multi-line message, each line is its own PRIVMSG; `pack-poll-options` splits the options onto further lines only when they would exceed a safe length (well under IRC's ~512-byte limit).

## Web view (`/polls`)

A new page (channel-scoped via `?c=#channel`, matching the existing `phrases`/`board` pages) lists recent published polls — one panel per poll showing the question, a status line (open/closed, deadline, vote count, winner, **creator and creation time**), and a per-option table with live vote counts and a proportional bar. Adds a `polls` nav link.

## Storage & migrations

- New tables `polls`, `poll_options`, `poll_votes` (`database/add-polls-tables.sql`, idempotent).
- Added to `bot-schema.sql.template` (first-run) and to the automatic startup-migration list (`init-first-run.lisp`), so a rebuild/restart updates an existing DB with no manual `psql`.

## Notes

- Verified the full system compiles/loads (`ql:quickload :harlie`).
- One vote per nick is enforced by a unique constraint; a duplicate vote is reported as "already voted".