### PR TITLE
Fix utterance triggering and ignore-command handling

### DIFF
--- a/config-template.lisp
+++ b/config-template.lisp
@@ -12,6 +12,14 @@
 (defparameter *ignore-phrase* "NOTIFY:: Help, I'm a bot!"
   "Bot emits this phrase on channel join to announce its botness.")
 
+;; How chatty the bot is.  Probability [0.0-1.0] that it fires an
+;; unprompted Markov reply to a message that contains no trigger word and
+;; does not address the bot by name.  0.0 disables spontaneous chatter.
+;; Rebindable at runtime from the Slynk REPL.
+(defparameter *spontaneous-reply-chance* 0.08
+  "Probability [0.0-1.0] that the bot fires an unprompted Markov reply to a
+message containing no trigger word.  0.0 disables spontaneous chatter.")
+
 ;; this sets the logging verbosity. 
 (log:config :debug)
 

--- a/irc-client.lisp
+++ b/irc-client.lisp
@@ -222,36 +222,46 @@ allowing for leading and trailing punctuation characters in the match."
   "Determine whether to trigger an utterance based on something we heard.
    If so, return the (possibly rewritten) token list against which to chain
    the output.  If not, return nil."
-  (let ((recognizer (make-name-detector (bot-nick context)))
-	(trigger-word (find-if #'(lambda (s) (member s token-list :test #'string-equal)) (trigger-list channel))))
-    (cond ((> 10 (length (trigger-list channel)))
-	   (progn
-	     (log:debug "[~&in triggered] ~A~%" (trigger-list channel))
-	     (setf (trigger-list channel) (append (trigger-list channel) token-list))
-	     (log:debug "[~&after append token list in triggered] ~A~%" (trigger-list channel))
-	     (when (< 10 (length (trigger-list channel)))
-	       (setf (trigger-list channel) (subseq (trigger-list channel) 0 10)))
-	     nil)
-	   (remove-if-not recognizer token-list)
-	   (mapcar #'(lambda (s)
-		       (if (funcall recognizer s)
-			   (regex-replace (string-upcase (bot-nick context)) (string-upcase s) sender)
-			   s))
-		   token-list))
-	  (trigger-word
-	   (progn
-	     (setf (trigger-list channel)
-		   (remove trigger-word (trigger-list channel) :test #'string=))
-	     (setf (trigger-list channel)
-		   (append (trigger-list channel)
-			   (random-words context
-					 (- 10 (length (trigger-list channel)))
-					 #'acceptable-word-p)))
-	     token-list))
-	  ((< (random 1.0) *spontaneous-reply-chance*)
-	   (log:debug "[~&in triggered] spontaneous reply fired~%")
-	   token-list)
-	  (t nil))))
+  (let* ((recognizer (make-name-detector (bot-nick context)))
+	 (addressed (some recognizer token-list))
+	 (trigger-word (find-if #'(lambda (s)
+				    (member s token-list :test #'string-equal))
+				(trigger-list channel))))
+    ;; Keep the channel trigger list topped up to 10 words so the
+    ;; trigger-word path below has something to match against.  A sparse
+    ;; chaining database can leave it short, so refill from the incoming
+    ;; tokens first and truncate back to 10.
+    (when (< (length (trigger-list channel)) 10)
+      (log:debug "[~&in triggered] topping up trigger list: ~A~%" (trigger-list channel))
+      (setf (trigger-list channel) (append (trigger-list channel) token-list))
+      (when (< 10 (length (trigger-list channel)))
+	(setf (trigger-list channel) (subseq (trigger-list channel) 0 10))))
+    (cond
+      ;; The bot was addressed by name: always reply, rewriting the name
+      ;; to the speaker so the Markov chain answers in the second person.
+      (addressed
+       (log:debug "[~&in triggered] addressed by name~%")
+       (mapcar #'(lambda (s)
+		   (if (funcall recognizer s)
+		       (regex-replace (string-upcase (bot-nick context))
+				      (string-upcase s) sender)
+		       s))
+	       token-list))
+      ;; A trigger word was heard: reply and refresh that slot.
+      (trigger-word
+       (setf (trigger-list channel)
+	     (remove trigger-word (trigger-list channel) :test #'string=))
+       (setf (trigger-list channel)
+	     (append (trigger-list channel)
+		     (random-words context
+				   (- 10 (length (trigger-list channel)))
+				   #'acceptable-word-p)))
+       token-list)
+      ;; Otherwise, occasionally pipe up unprompted.
+      ((< (random 1.0) *spontaneous-reply-chance*)
+       (log:debug "[~&in triggered] spontaneous reply fired~%")
+       token-list)
+      (t nil))))
 
 (defun extract-urls (text)
   (all-matches-as-strings "((http|https)://[^\\s]+)|(www[.][^\\s.][^\\s]*[.][^\\s.][^\\s]*)" text))
@@ -284,7 +294,8 @@ allowing for leading and trailing punctuation characters in the match."
     (return-from ignoring nil))
 
   (let ((ignore-phrase *ignore-phrase*))
-    (cond ((string= ignore-phrase text)
+    (cond ((string-equal (string-trim '(#\Space #\Tab #\Return #\Newline) text)
+                         (string-trim '(#\Space #\Tab #\Return #\Newline) ignore-phrase))
            (log:debug "Caught BOT Ignore Phrase, ignoring cousin from across the river: ~A on channel: ~A"
                       sender channel)
 	   (when (start-ignoring connection sender channel-name)
@@ -313,8 +324,11 @@ allowing for leading and trailing punctuation characters in the match."
                             (return-from ignoring (ignored channel-user-ignored?))
                             (return-from ignoring nil))))
                     (t (return-from ignoring nil))))))
-    ;; As there was an ignore toggle command, it's been handled and so should be ignored.
-    nil))
+    ;; Reaching here means one of the ignore commands above (the bot
+    ;; announce phrase, !ignoreme, or !ignoreme off) matched and has been
+    ;; handled, so report t to stop msg-hook from also routing it to the
+    ;; plugin dispatcher (which would answer "unknown command").
+    t))
 
 (defun msg-hook (conn msg sender channel-name text action)
   "Handle an incoming message.

--- a/util.lisp
+++ b/util.lisp
@@ -217,9 +217,11 @@ a single web-server-name."
 ;; Tunable at runtime (e.g. from the Slynk REPL) to make the bot more or
 ;; less chatty and sarcastic without rebuilding.
 
-(defparameter *spontaneous-reply-chance* 0.08
-  "Probability [0.0-1.0] that the bot fires an unprompted Markov reply to a
-message containing no trigger word.  0.0 disables spontaneous chatter.")
+;; *spontaneous-reply-chance* is defined in config.lisp so it can be tuned
+;; per site without editing this file.  It controls the probability
+;; [0.0-1.0] that the bot fires an unprompted Markov reply to a message
+;; containing no trigger word.  It is still rebindable at runtime from the
+;; REPL.
 
 (defparameter *snark-chance* 0.10
   "Probability [0.0-1.0] that the bot tags a Markov reply with a sarcastic

--- a/util.lisp
+++ b/util.lisp
@@ -217,11 +217,15 @@ a single web-server-name."
 ;; Tunable at runtime (e.g. from the Slynk REPL) to make the bot more or
 ;; less chatty and sarcastic without rebuilding.
 
-;; *spontaneous-reply-chance* is defined in config.lisp so it can be tuned
-;; per site without editing this file.  It controls the probability
-;; [0.0-1.0] that the bot fires an unprompted Markov reply to a message
-;; containing no trigger word.  It is still rebindable at runtime from the
+;; The canonical place to tune this per site is config.lisp (and the
+;; shipped config-template.lisp), both of which load before this file and
+;; may set the value with defparameter.  We use defvar here as a safe
+;; fallback so the variable is always bound even on a deployment whose
+;; config.lisp predates this knob.  Still rebindable at runtime from the
 ;; REPL.
+(defvar *spontaneous-reply-chance* 0.08
+  "Probability [0.0-1.0] that the bot fires an unprompted Markov reply to a
+message containing no trigger word.  0.0 disables spontaneous chatter.")
 
 (defparameter *snark-chance* 0.10
   "Probability [0.0-1.0] that the bot tags a Markov reply with a sarcastic


### PR DESCRIPTION
## Summary

Digs into Marv's utterance frequency and the ignore path.

### triggered

The first `cond` clause held three body forms, so when a channel's trigger list was under-filled the clause returned the token list and the bot replied to every message, bypassing `*spontaneous-reply-chance*` entirely. Name detection was also trapped in that branch and never ran once the list was full.

Reworked into a top-up step followed by independent clauses in priority order: addressed by name, trigger word heard, then spontaneous chance. The engagement knob is now actually consulted and direct-address replies work with a full trigger list.

### ignore path

`ignoring` returned `nil` after handling `!ignoreme`, `!ignoreme off`, or the bot announce phrase, so `msg-hook` still routed the command to the plugin dispatcher and emitted "ignoreme: unknown command". It now returns `t` so handled ignore commands stop further processing. The announce phrase is also matched case-insensitively and trimmed of surrounding whitespace, so other clients' phrasing still trips the ignore.

### config

`*spontaneous-reply-chance*` is surfaced in `config.lisp` and `config-template.lisp` so engagement is tunable per site without editing source. A `defvar` fallback in `util.lisp` (which loads after `config`) keeps the variable bound on deployments whose `config.lisp` predates the knob, while letting a config value win.

## Testing

`(ql:quickload :harlie)` compiles clean. Deployed to a live bot and confirmed `!ignoreme` no longer emits the spurious unknown-command reply.